### PR TITLE
MER-173

### DIFF
--- a/venus/src/redux/spot-filters.jsx
+++ b/venus/src/redux/spot-filters.jsx
@@ -10,7 +10,7 @@ export const spotFiltersSlice = createSlice({
   initialState,
   reducers: {
     setFilters(state, action) {
-      state.name = action.payload.name || state.name;
+      state.name = action.payload.name;
       state.minRating =
         action.payload.minRating !== undefined
           ? action.payload.minRating


### PR DESCRIPTION
Naprawa filtrowania spotów po nazwie. Wcześniej po wpisaniu nazwy i jej wyczyszczeniu pokazywane były spoty pasujące do poprzedniego filtra.