### PR TITLE
MER-193 Renamed Test classes to comply with Surefire naming conventions, created Test case that checks if all Test classes meet to these conventions

### DIFF
--- a/vulcanus/src/test/java/com/merkury/vulcanus/TestNamingConventionTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/TestNamingConventionTest.java
@@ -1,0 +1,27 @@
+package com.merkury.vulcanus;
+
+import org.junit.jupiter.api.Test;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestNamingConventionTest {
+
+    @Test
+    public void testTestFilesNamingConvention() throws Exception {
+        Path testDirectory = Paths.get("src/test");
+
+        try (Stream<Path> paths = Files.walk(testDirectory)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .forEach(path -> {
+                        String fileName = path.getFileName().toString();
+                        String className = fileName.substring(0, fileName.lastIndexOf(".java"));
+                        assertTrue(className.endsWith("Test"),
+                                "File " + fileName + " does not end with word 'Test'");
+                    });
+        }
+    }
+}

--- a/vulcanus/src/test/java/com/merkury/vulcanus/controllers/account/AccountControllerWithServerStartupTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/controllers/account/AccountControllerWithServerStartupTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class AccountControllerTestWithServerStartup {
+class AccountControllerWithServerStartupTest {
 
     @LocalServerPort
     private int port;
@@ -92,7 +92,7 @@ class AccountControllerTestWithServerStartup {
     }
 
     @Test
-    @DisplayName("Registration with invalid email format returns 400")
+    @DisplayName("Registration with invalid email format returns 422")
     void registerWithInvalidEmailFormatReturns400() {
         var registerDto = new UserRegisterDto("newuser", "invalid-email", "Password123!");
         HttpHeaders headers = new HttpHeaders();
@@ -105,7 +105,7 @@ class AccountControllerTestWithServerStartup {
                 String.class
         );
 
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(400));
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(422));
     }
 
     @Test

--- a/vulcanus/src/test/java/com/merkury/vulcanus/test/TestControllerWithAppContextStartupTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/test/TestControllerWithAppContextStartupTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-class TestControllerTestWithAppContextStartup {
+class TestControllerWithAppContextStartupTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/vulcanus/src/test/java/com/merkury/vulcanus/test/TestControllerWithServerStartupTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/test/TestControllerWithServerStartupTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class TestControllerTestWithServerStartup {
+class TestControllerWithServerStartupTest {
 
     @LocalServerPort
     private int port;


### PR DESCRIPTION
This pull request introduces changes to the test naming conventions and updates to the status code assertions in the `vulcanus` project. The most important changes include the addition of a new test for naming conventions, renaming of test classes to follow the new naming conventions, and updating the expected status code for invalid email format registration tests.

### Test Naming Conventions:

* [`vulcanus/src/test/java/com/merkury/vulcanus/TestNamingConventionTest.java`](diffhunk://#diff-1995084676b0f84bdb225180e10b5fe7c61d4837db41f335211b8f913e459e4fR1-R27): Added a new test to ensure that all test files end with the word 'Test'.

### Renaming Test Classes:

* [`vulcanus/src/test/java/com/merkury/vulcanus/controllers/account/AccountControllerWithServerStartupTest.java`](diffhunk://#diff-cb90a14e11fd91f0cc9fb5dafe1ff7b1a628c6cb856ee9af9cc0e66fb3072210L28-R28): Renamed from `AccountControllerTestWithServerStartup` to follow the new naming conventions.
* [`vulcanus/src/test/java/com/merkury/vulcanus/test/TestControllerWithAppContextStartupTest.java`](diffhunk://#diff-c0f057d63d30e26907a15b7329966862744d577624770927704e2460cac9dad2L18-R18): Renamed from `TestControllerTestWithAppContextStartup` to follow the new naming conventions.
* [`vulcanus/src/test/java/com/merkury/vulcanus/test/TestControllerWithServerStartupTest.java`](diffhunk://#diff-09c72637b7aa2d5dc31e83f2102fc29243533dc28ab82e6a40e7a4ab4d05015aL15-R15): Renamed from `TestControllerTestWithServerStartup` to follow the new naming conventions.

### Status Code Assertions:

* [`vulcanus/src/test/java/com/merkury/vulcanus/controllers/account/AccountControllerWithServerStartupTest.java`](diffhunk://#diff-cb90a14e11fd91f0cc9fb5dafe1ff7b1a628c6cb856ee9af9cc0e66fb3072210L95-R95): Updated the expected status code from 400 to 422 for the test `registerWithInvalidEmailFormatReturns400`. [[1]](diffhunk://#diff-cb90a14e11fd91f0cc9fb5dafe1ff7b1a628c6cb856ee9af9cc0e66fb3072210L95-R95) [[2]](diffhunk://#diff-cb90a14e11fd91f0cc9fb5dafe1ff7b1a628c6cb856ee9af9cc0e66fb3072210L108-R108)