### PR TITLE
fix/MER-253

### DIFF
--- a/venus/src/layout/Layout.jsx
+++ b/venus/src/layout/Layout.jsx
@@ -3,32 +3,25 @@ import Notification from "../components/notification/Notification.jsx";
 import Sidebar from "./sidebar/Sidebar.tsx";
 import { useEffect } from "react";
 import MobileBar from "./mobile-bar/MobileBar";
-import { useToggleState } from "../hooks/useToggleState";
 import useDispatchTyped from "../hooks/useDispatchTyped";
 import { sidebarAction } from "../redux/sidebar";
 
 export default function Layout() {
   const location = useLocation();
   const isMapPage = location.pathname === "/map";
-  const [isSidebarOpen, setIsSidebarOpen, toggleSidebar] =
-    useToggleState(false);
   const dispatch = useDispatchTyped();
 
   useEffect(() => {
     if (location.pathname.includes("account") && window.innerWidth >= 1280) {
-      setIsSidebarOpen(true);
+      dispatch(sidebarAction.setIsSidebarOpen(true));
     }
   }, [location]);
 
-  useEffect(() => {
-    dispatch(sidebarAction.setIsSidebarOpen(isSidebarOpen));
-  }, [isSidebarOpen]);
-
   return (
     <div className={`${isMapPage ? "relative" : "flex"} min-h-screen`}>
-      <Sidebar isSidebarOpen={isSidebarOpen} onToggle={toggleSidebar} />
+      <Sidebar />
       <main className="relative flex w-full flex-col items-center justify-center">
-        <MobileBar onToggle={toggleSidebar} />
+        <MobileBar />
         <Notification title="test" message="message" />
         <Outlet />
       </main>

--- a/venus/src/layout/mobile-bar/MobileBar.tsx
+++ b/venus/src/layout/mobile-bar/MobileBar.tsx
@@ -1,13 +1,15 @@
 import { IoMenu } from "react-icons/io5";
+import useDispatchTyped from "../../hooks/useDispatchTyped";
+import { sidebarAction } from "../../redux/sidebar";
 
-interface MobileBarProps {
-  onToggle: () => void;
-}
+export default function MobileBar() {
+  const dispatch = useDispatchTyped();
 
-export default function MobileBar({ onToggle }: MobileBarProps) {
+  const handleToggle = () => dispatch(sidebarAction.toggleSidebar());
+
   return (
     <div className="bg-violetDark text-darkText absolute top-0 left-0 z-20 flex w-full items-center justify-between p-2 xl:hidden">
-      <button onClick={onToggle} className="ml-2 w-fit cursor-pointer">
+      <button onClick={handleToggle} className="ml-2 w-fit cursor-pointer">
         <IoMenu size={40} />
       </button>
       <span className="mr-2 font-semibold">Merkury</span>

--- a/venus/src/layout/sidebar/Sidebar.tsx
+++ b/venus/src/layout/sidebar/Sidebar.tsx
@@ -10,14 +10,10 @@ import {
   userLoggedLinks,
 } from "../../utils/sidebar/sidebarLinks";
 
-interface SidebarProps {
-  isSidebarOpen: boolean;
-  onToggle: () => void;
-}
-
-export default function Sidebar({ isSidebarOpen, onToggle }: SidebarProps) {
+export default function Sidebar() {
   const [isDark, toggleDarkMode] = useDarkMode();
   const isLogged = useSelectorTyped((state) => state.account.isLogged);
+  const isSidebarOpen = useSelectorTyped((state) => state.sidebar.isOpen);
   const location = useLocation();
   const isAccountPage = location.pathname.includes("/account");
   const isChatPage = location.pathname.includes("/chat");
@@ -33,7 +29,7 @@ export default function Sidebar({ isSidebarOpen, onToggle }: SidebarProps) {
       className={`bg-violetDark text-darkText fixed top-0 left-0 z-50 flex h-screen shrink-0 flex-col justify-between py-2 transition-all duration-300 ${isAccountPage || isChatPage ? "xl:sticky" : "absolute"} ${isSidebarOpen ? "w-full translate-x-0 xl:w-[220px]" : "w-[220px] -translate-x-full p-0 xl:w-[70px] xl:translate-x-0"}`}
     >
       <div className="flex flex-col space-y-10">
-        <SidebarToggleButton onToggle={onToggle} />
+        <SidebarToggleButton />
         <SidebarSection showBottomHr={true}>
           <SidebarList links={allLinks} isSidebarOpen={isSidebarOpen} />
         </SidebarSection>

--- a/venus/src/layout/sidebar/components/SidebarToggleButton.tsx
+++ b/venus/src/layout/sidebar/components/SidebarToggleButton.tsx
@@ -1,18 +1,18 @@
 import { IoMenu } from "react-icons/io5";
+import { sidebarAction } from "../../../redux/sidebar";
+import useDispatchTyped from "../../../hooks/useDispatchTyped";
 
-interface SidebarToggleButtonProps {
-  onToggle: () => void;
-}
+export default function SidebarToggleButton() {
+  const dispatch = useDispatchTyped();
 
-export default function SidebarToggleButton({
-  onToggle,
-}: SidebarToggleButtonProps) {
+  const handleToggle = () => dispatch(sidebarAction.toggleSidebar());
+
   return (
     <div className="bg-violetDark mx-2 flex items-center justify-between">
       <button
         type="button"
         className="ml-2 w-fit cursor-pointer"
-        onClick={onToggle}
+        onClick={handleToggle}
       >
         <IoMenu size={40} />
       </button>

--- a/venus/src/layout/sidebar/components/sidebar-item/SidebarItemLink.tsx
+++ b/venus/src/layout/sidebar/components/sidebar-item/SidebarItemLink.tsx
@@ -2,7 +2,7 @@ import { NavLink } from "react-router-dom";
 import SidebarItemContent from "./SidebarItemContent";
 import { SidebarLink } from "../../../../model/interface/sidebar/link";
 import useDispatchTyped from "../../../../hooks/useDispatchTyped";
-import { sidebarAction } from "../../../../redux/sidebar";
+import { closeSidebar } from "../../../../redux/sidebar";
 
 interface SidebarItemLinkProps {
   link: SidebarLink;
@@ -21,7 +21,7 @@ export default function SidebarItemLink({
 }: SidebarItemLinkProps) {
   const dispatch = useDispatchTyped();
 
-  const handleClose = () => dispatch(sidebarAction.closeSidebar());
+  const handleClose = () => dispatch(closeSidebar());
 
   return (
     <NavLink

--- a/venus/src/layout/sidebar/components/sidebar-item/SidebarItemLink.tsx
+++ b/venus/src/layout/sidebar/components/sidebar-item/SidebarItemLink.tsx
@@ -1,6 +1,8 @@
 import { NavLink } from "react-router-dom";
 import SidebarItemContent from "./SidebarItemContent";
 import { SidebarLink } from "../../../../model/interface/sidebar/link";
+import useDispatchTyped from "../../../../hooks/useDispatchTyped";
+import { sidebarAction } from "../../../../redux/sidebar";
 
 interface SidebarItemLinkProps {
   link: SidebarLink;
@@ -17,10 +19,15 @@ export default function SidebarItemLink({
   isSidebarOpen,
   isTooltipShown,
 }: SidebarItemLinkProps) {
+  const dispatch = useDispatchTyped();
+
+  const handleClose = () => dispatch(sidebarAction.closeSidebar());
+
   return (
     <NavLink
       to={link.to}
       end
+      onClick={handleClose}
       onMouseEnter={showTooltip}
       onMouseLeave={hideTooltip}
       className={({ isActive }) =>

--- a/venus/src/layout/sidebar/components/sidebar-item/SidebarItemSubmenuLink.tsx
+++ b/venus/src/layout/sidebar/components/sidebar-item/SidebarItemSubmenuLink.tsx
@@ -1,5 +1,7 @@
 import { NavLink } from "react-router-dom";
 import { SidebarSubmenuLink } from "../../../../model/interface/sidebar/link";
+import useDispatchTyped from "../../../../hooks/useDispatchTyped";
+import { sidebarAction } from "../../../../redux/sidebar";
 
 interface SidebarItemSubmenuProps {
   link: SidebarSubmenuLink;
@@ -8,10 +10,15 @@ interface SidebarItemSubmenuProps {
 export default function SidebarItemSubmenuLink({
   link,
 }: SidebarItemSubmenuProps) {
+  const dispatch = useDispatchTyped();
+
+  const handleClose = () => dispatch(sidebarAction.closeSidebar());
+
   return (
     <NavLink
       to={link.to}
       end
+      onClick={handleClose}
       className={({ isActive }) =>
         `hover:bg-violetLight mx-2 flex items-center space-x-1 rounded-md text-gray-300 ${isActive ? "bg-violetLight" : ""}`
       }

--- a/venus/src/layout/sidebar/components/sidebar-item/SidebarItemSubmenuLink.tsx
+++ b/venus/src/layout/sidebar/components/sidebar-item/SidebarItemSubmenuLink.tsx
@@ -1,7 +1,7 @@
 import { NavLink } from "react-router-dom";
 import { SidebarSubmenuLink } from "../../../../model/interface/sidebar/link";
 import useDispatchTyped from "../../../../hooks/useDispatchTyped";
-import { sidebarAction } from "../../../../redux/sidebar";
+import { closeSidebar } from "../../../../redux/sidebar";
 
 interface SidebarItemSubmenuProps {
   link: SidebarSubmenuLink;
@@ -12,7 +12,7 @@ export default function SidebarItemSubmenuLink({
 }: SidebarItemSubmenuProps) {
   const dispatch = useDispatchTyped();
 
-  const handleClose = () => dispatch(sidebarAction.closeSidebar());
+  const handleClose = () => dispatch(closeSidebar());
 
   return (
     <NavLink

--- a/venus/src/redux/sidebar.tsx
+++ b/venus/src/redux/sidebar.tsx
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { AppDispatch } from "./store";
 
 type sidebarInitialState = {
   isOpen: boolean;
@@ -8,18 +9,36 @@ const initialState: sidebarInitialState = {
   isOpen: false,
 };
 
+/**
+ * Thunk to close the sidebar on smaller screens.
+ *
+ * This action will close the sidebar **only if the current viewport width is less than 1280px**.
+ *
+ * @example
+ * dispatch(closeSidebar());
+ */
+export const closeSidebar = () => (dispatch: AppDispatch) => {
+  if (window.innerWidth < 1280) {
+    dispatch(sidebarAction.setIsSidebarOpen(false));
+  }
+};
+
 export const sidebarSlice = createSlice({
   name: "sidebar",
   initialState,
   reducers: {
+    /**
+     * Sets the sidebar open/closed explicitly.
+     * @param state Current sidebar state.
+     * @param action Payload: `true` to open, `false` to close.
+     */
     setIsSidebarOpen(state, action) {
       state.isOpen = action.payload;
     },
-    closeSidebar(state) {
-      if (window.innerWidth < 1280) {
-        state.isOpen = false;
-      }
-    },
+    /**
+     * Toggles the current open/close state of the sidebar.
+     * No arguments needed.
+     */
     toggleSidebar(state) {
       state.isOpen = !state.isOpen;
     },

--- a/venus/src/redux/sidebar.tsx
+++ b/venus/src/redux/sidebar.tsx
@@ -15,6 +15,14 @@ export const sidebarSlice = createSlice({
     setIsSidebarOpen(state, action) {
       state.isOpen = action.payload;
     },
+    closeSidebar(state) {
+      if (window.innerWidth < 1280) {
+        state.isOpen = false;
+      }
+    },
+    toggleSidebar(state) {
+      state.isOpen = !state.isOpen;
+    },
   },
 });
 

--- a/venus/src/test/integration/Sidebar.test.jsx
+++ b/venus/src/test/integration/Sidebar.test.jsx
@@ -6,6 +6,7 @@ import { configureStore } from "@reduxjs/toolkit";
 import { accountSlice } from "../../redux/account";
 import userEvent from "@testing-library/user-event";
 import Sidebar from "../../layout/sidebar/Sidebar";
+import { sidebarSlice } from "../../redux/sidebar";
 
 const queryClient = new QueryClient();
 
@@ -13,6 +14,7 @@ const renderSidebar = () => {
   const store = configureStore({
     reducer: {
       account: accountSlice.reducer,
+      sidebar: sidebarSlice.reducer,
     },
   });
 

--- a/venus/src/test/unit/Sidebar.test.jsx
+++ b/venus/src/test/unit/Sidebar.test.jsx
@@ -5,13 +5,15 @@ import { configureStore } from "@reduxjs/toolkit";
 import { MemoryRouter } from "react-router-dom";
 import { accountSlice } from "../../redux/account";
 import Sidebar from "../../layout/sidebar/Sidebar";
+import { sidebarSlice } from "../../redux/sidebar";
 
 const queryClient = new QueryClient();
 
-const renderSidebar = (preloadedState, pathname, isSidebarOpen = false) => {
+const renderSidebar = (preloadedState, pathname) => {
   const store = configureStore({
     reducer: {
       account: accountSlice.reducer,
+      sidebar: sidebarSlice.reducer,
     },
     preloadedState,
   });
@@ -20,7 +22,7 @@ const renderSidebar = (preloadedState, pathname, isSidebarOpen = false) => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[pathname]}>
         <QueryClientProvider client={queryClient}>
-          <Sidebar isSidebarOpen={isSidebarOpen} onToggle={() => {}} />
+          <Sidebar />
         </QueryClientProvider>
       </MemoryRouter>
     </Provider>,
@@ -34,6 +36,9 @@ describe("Sidebar component unit tests", () => {
         {
           account: {
             isLogged: false,
+          },
+          sidebar: {
+            isOpen: false,
           },
         },
         "/",
@@ -154,9 +159,11 @@ describe("Sidebar component unit tests", () => {
           account: {
             isLogged: false,
           },
+          sidebar: {
+            isOpen: true,
+          },
         },
         "/",
-        true,
       );
     });
 
@@ -200,9 +207,11 @@ describe("Sidebar component unit tests", () => {
           account: {
             isLogged: true,
           },
+          sidebar: {
+            isOpen: true,
+          },
         },
         "/account/profile",
-        true,
       );
     });
 


### PR DESCRIPTION
This pull request refactors the sidebar functionality in the `venus` project to improve state management, reduce prop drilling, and enhance code readability. The changes include replacing local state management with Redux for the sidebar, updating components to use the new Redux actions, and modifying tests to accommodate the updated implementation.

### Sidebar State Management Refactor:

* [`venus/src/redux/sidebar.tsx`](diffhunk://#diff-8459f89fcfc61df10e76416225167855eae2e04cadc45c36107fcb559273b453R12-R44): Introduced a new Redux slice (`sidebarSlice`) to manage the sidebar's state, including actions for explicitly setting (`setIsSidebarOpen`), toggling (`toggleSidebar`), and conditionally closing (`closeSidebar`) the sidebar. Added detailed documentation for these actions.

### Component Updates:

* [`venus/src/layout/Layout.jsx`](diffhunk://#diff-82e35592ca46356a12d98649b6d11df954bd601be4198b509d5dc8e286e3db0cL6-R24): Removed the `useToggleState` hook and replaced local state management with Redux actions (`sidebarAction.setIsSidebarOpen`). Updated the `Sidebar` and `MobileBar` components to no longer require `isSidebarOpen` or `onToggle` props.
* [`venus/src/layout/sidebar/Sidebar.tsx`](diffhunk://#diff-940539102dd775cc947ca3014232e20b582dd12c84aac4bbb88547678fee47efL13-R16): Updated the `Sidebar` component to use Redux (`useSelectorTyped`) for determining the open state (`isSidebarOpen`). Removed the `onToggle` prop. [[1]](diffhunk://#diff-940539102dd775cc947ca3014232e20b582dd12c84aac4bbb88547678fee47efL13-R16) [[2]](diffhunk://#diff-940539102dd775cc947ca3014232e20b582dd12c84aac4bbb88547678fee47efL36-R32)
* [`venus/src/layout/mobile-bar/MobileBar.tsx`](diffhunk://#diff-9e7f663fc39034c53d17f548e030beaf6fd6cf2cbe35b859bc7e0debeba55d5cR2-R12): Refactored `MobileBar` to use Redux actions (`sidebarAction.toggleSidebar`) directly for toggling the sidebar. Removed the `onToggle` prop.
* [`venus/src/layout/sidebar/components/SidebarToggleButton.tsx`](diffhunk://#diff-7452aa58572c7676974b08ceaf1475b274b92462e926667c7febee832397e9f9R2-R15): Updated `SidebarToggleButton` to use Redux actions (`sidebarAction.toggleSidebar`) directly for toggling the sidebar. Removed the `onToggle` prop.
* `venus/src/layout/sidebar/components/sidebar-item/SidebarItemLink.tsx` and `SidebarItemSubmenuLink.tsx`: Added a Redux action (`closeSidebar`) to close the sidebar when a link is clicked, ensuring better UX on smaller screens. [[1]](diffhunk://#diff-301f01bb6c770ec1c221c70bf37d72be306a165d5f4f12430faa2aa44bef7107R22-R30) [[2]](diffhunk://#diff-d8c2f5412af8606b91f7cfe29f5537856a8e5cad068e0e58120d5adb6a9e7c1cR13-R21)

### Test Updates:

* `venus/src/test/unit/Sidebar.test.jsx` and `venus/src/test/integration/Sidebar.test.jsx`: Updated tests to integrate the new `sidebarSlice` reducer into the Redux store. Removed `isSidebarOpen` and `onToggle` props from `Sidebar` in test cases. Adjusted preloaded state to include `sidebar` state. [[1]](diffhunk://#diff-b0367cc8bd7d660f7a79802ed512d2e9cb62c63a289e7decf0342a1cd1769615R9-R17) [[2]](diffhunk://#diff-e99efc9b1bda4fb9a9886b98d307df33e4d7cb76a1255297f310a812656a51e2R8-R16) [[3]](diffhunk://#diff-e99efc9b1bda4fb9a9886b98d307df33e4d7cb76a1255297f310a812656a51e2L23-R25) [[4]](diffhunk://#diff-e99efc9b1bda4fb9a9886b98d307df33e4d7cb76a1255297f310a812656a51e2R40-R42) [[5]](diffhunk://#diff-e99efc9b1bda4fb9a9886b98d307df33e4d7cb76a1255297f310a812656a51e2R162-L159) [[6]](diffhunk://#diff-e99efc9b1bda4fb9a9886b98d307df33e4d7cb76a1255297f310a812656a51e2R210-L205)