### PR TITLE
Remove branch filters for feature and fix in CI configuration

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -2,9 +2,6 @@ name: Java CI
 
 on:
   push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
     paths:
       - 'vulcanus/**'
   pull_request:

--- a/.github/workflows/react-ci.yml
+++ b/.github/workflows/react-ci.yml
@@ -2,9 +2,6 @@ name: React CI
 
 on:
   push:
-    branches:
-      - 'feature/**'
-      - 'fix/**'
     paths:
       - 'venus/**'
   pull_request:


### PR DESCRIPTION
This pull request updates the CI workflows for Java and React projects. The changes remove branch-specific triggers to streamline the workflows and focus on path-based triggers.

Workflow updates:

* [`.github/workflows/java-ci.yml`](diffhunk://#diff-30032f912558b3db8571286ce51ce8687b578298bc5e0758ddc8accd7c23dfbbL5-L7): Removed branch-specific triggers (`feature/**` and `fix/**`) from the Java CI workflow to rely solely on path-based triggers for the `vulcanus` directory.
* [`.github/workflows/react-ci.yml`](diffhunk://#diff-33516bc76d953d1143666313e547eb4c70e5ffff1dad62bbdabc33736fb59da3L5-L7): Removed branch-specific triggers (`feature/**` and `fix/**`) from the React CI workflow to rely solely on path-based triggers for the `venus` directory.