### PR TITLE
refactor/MER-283

### DIFF
--- a/venus/src/http/spots-data.ts
+++ b/venus/src/http/spots-data.ts
@@ -74,15 +74,6 @@ export async function fetchSpotsDataById(
     return (await axios.get(`${BASE_URL}/public/spot/${id}`)).data;
 }
 
-export async function fetchUserFavouriteSpots(page) {
-    return (
-        await axios.get(`${BASE_URL}/spot/favourites`, {
-            params: { page },
-            withCredentials: true,
-        })
-    ).data;
-}
-
 export async function addSpotToFavourites(spotId) {
     return await axios.patch(
         `${BASE_URL}/spot/favourites/add/${spotId}`,

--- a/venus/src/http/user-dashboard.ts
+++ b/venus/src/http/user-dashboard.ts
@@ -10,6 +10,9 @@ import { DateSortType } from "../model/enum/account/photos/dateSortType";
 import DatedCommentsGroup from "../model/interface/account/comments/datedCommentsGroup";
 import UserEditData from "../model/interface/account/settings/userEditData";
 import UserData from "../model/interface/account/settings/userData";
+import { DatedMediaGroupPageDto } from "../model/interface/account/media/datedMediaGroupPageDto";
+import { FavoriteSpotPageDto } from "../model/interface/account/favorite-spots/favoriteSpotPageDto";
+import { DatedCommentsGroupPageDto } from "../model/interface/account/comments/datedCommentsGroupPageDto";
 const BASE_URL = import.meta.env.VITE_MERKURY_BASE_URL;
 
 export async function getUserOwnProfile(): Promise<UserProfile> {
@@ -186,7 +189,7 @@ export async function getSortedUserPhotos(
     to: string | null,
     page: number,
     size: number,
-): Promise<DatedMediaGroup[]> {
+): Promise<DatedMediaGroupPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/photos`, {
             withCredentials: true,
@@ -199,7 +202,7 @@ export async function getUserFavoriteSpots(
     type: FavoriteSpotsListType,
     page: number,
     size: number,
-): Promise<FavoriteSpot[]> {
+): Promise<FavoriteSpotPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/favorite-spots`, {
             withCredentials: true,
@@ -238,7 +241,7 @@ export async function getAllUserComments(
     to: string | null,
     page: number,
     size: number,
-): Promise<DatedCommentsGroup[]> {
+): Promise<DatedCommentsGroupPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/comments`, {
             withCredentials: true,
@@ -267,7 +270,7 @@ export async function getSortedUserMovies(
     to: string | null,
     page: number,
     size: number,
-): Promise<DatedMediaGroup[]> {
+): Promise<DatedMediaGroupPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/movies`, {
             withCredentials: true,

--- a/venus/src/http/user-dashboard.ts
+++ b/venus/src/http/user-dashboard.ts
@@ -33,19 +33,36 @@ export async function getProfileForViewer(
     ).data;
 }
 
-export async function getUserOwnFriends(): Promise<SocialDto[]> {
+export async function getUserOwnFriends(
+    page: number,
+    size: number,
+): Promise<SocialDto[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/friends`, {
             withCredentials: true,
+            params: {
+                page,
+                size,
+            },
         })
     ).data;
 }
 
 export async function getUserFriendsForViewer(
     username: string,
+    page: number,
+    size: number,
 ): Promise<SocialDto[]> {
     return (
-        await axios.get(`${BASE_URL}/public/user-dashboard/friends/${username}`)
+        await axios.get(
+            `${BASE_URL}/public/user-dashboard/friends/${username}`,
+            {
+                params: {
+                    page,
+                    size,
+                },
+            },
+        )
     ).data;
 }
 
@@ -73,38 +90,68 @@ export async function editUserFriends({
     ).data;
 }
 
-export async function getUserOwnFollowed(): Promise<SocialDto[]> {
+export async function getUserOwnFollowed(
+    page: number,
+    size: number,
+): Promise<SocialDto[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/followed`, {
             withCredentials: true,
+            params: {
+                page,
+                size,
+            },
         })
     ).data;
 }
 
 export async function getUserFollowedForViewer(
     username: string,
+    page: number,
+    size: number,
 ): Promise<SocialDto[]> {
     return (
         await axios.get(
             `${BASE_URL}/public/user-dashboard/followed/${username}`,
+            {
+                params: {
+                    page,
+                    size,
+                },
+            },
         )
     ).data;
 }
 
-export async function getUserOwnFollowers(): Promise<SocialDto[]> {
+export async function getUserOwnFollowers(
+    page: number,
+    size: number,
+): Promise<SocialDto[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/followers`, {
             withCredentials: true,
+            params: {
+                page,
+                size,
+            },
         })
     ).data;
 }
 
 export async function getUserFollowersForViewer(
     username: string,
+    page: number,
+    size: number,
 ): Promise<SocialDto[]> {
     return (
         await axios.get(
             `${BASE_URL}/public/user-dashboard/followers/${username}`,
+            {
+                params: {
+                    page,
+                    size,
+                },
+            },
         )
     ).data;
 }
@@ -133,32 +180,30 @@ export async function editUserFollowed({
     ).data;
 }
 
-interface DateRangeSortProps {
-    type: DateSortType;
-    from: string | null;
-    to: string | null;
-}
-
-export async function getSortedUserPhotos({
-    type,
-    from,
-    to,
-}: DateRangeSortProps): Promise<DatedMediaGroup[]> {
+export async function getSortedUserPhotos(
+    type: DateSortType,
+    from: string | null,
+    to: string | null,
+    page: number,
+    size: number,
+): Promise<DatedMediaGroup[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/photos`, {
             withCredentials: true,
-            params: { type, from, to },
+            params: { type, from, to, page, size },
         })
     ).data;
 }
 
 export async function getUserFavoriteSpots(
     type: FavoriteSpotsListType,
+    page: number,
+    size: number,
 ): Promise<FavoriteSpot[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/favorite-spots`, {
             withCredentials: true,
-            params: type,
+            params: { type, page, size },
         })
     ).data;
 }
@@ -187,15 +232,17 @@ export async function removeFavoriteSpot({
     ).data;
 }
 
-export async function getAllUserComments({
-    type,
-    from,
-    to,
-}: DateRangeSortProps): Promise<DatedCommentsGroup[]> {
+export async function getAllUserComments(
+    type: DateSortType,
+    from: string | null,
+    to: string | null,
+    page: number,
+    size: number,
+): Promise<DatedCommentsGroup[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/comments`, {
             withCredentials: true,
-            params: { type, from, to },
+            params: { type, from, to, page, size },
         })
     ).data;
 }
@@ -214,15 +261,17 @@ export async function getUserData(): Promise<UserData> {
     ).data;
 }
 
-export async function getSortedUserMovies({
-    type,
-    from,
-    to,
-}: DateRangeSortProps): Promise<DatedMediaGroup[]> {
+export async function getSortedUserMovies(
+    type: DateSortType,
+    from: string | null,
+    to: string | null,
+    page: number,
+    size: number,
+): Promise<DatedMediaGroup[]> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/movies`, {
             withCredentials: true,
-            params: { type, from, to },
+            params: { type, from, to, page, size },
         })
     ).data;
 }

--- a/venus/src/http/user-dashboard.ts
+++ b/venus/src/http/user-dashboard.ts
@@ -60,10 +60,14 @@ export async function editUserFriends({
 }: EditUserFriendsProps): Promise<void> {
     return (
         await axios.patch(
-            `${BASE_URL}/user-dashboard/friends?friendUsername=${friendUsername}&type=${type}`,
+            `${BASE_URL}/user-dashboard/friends`,
             {},
             {
                 withCredentials: true,
+                params: {
+                    friendUsername,
+                    type,
+                },
             },
         )
     ).data;
@@ -116,10 +120,14 @@ export async function editUserFollowed({
 }: EditUserFollowedProps): Promise<void> {
     return (
         await axios.patch(
-            `${BASE_URL}/user-dashboard/followed?followedUsername=${followedUsername}&type=${type}`,
+            `${BASE_URL}/user-dashboard/followed`,
             {},
             {
                 withCredentials: true,
+                params: {
+                    followedUsername,
+                    type,
+                },
             },
         )
     ).data;
@@ -148,12 +156,10 @@ export async function getUserFavoriteSpots(
     type: FavoriteSpotsListType,
 ): Promise<FavoriteSpot[]> {
     return (
-        await axios.get(
-            `${BASE_URL}/user-dashboard/favorite-spots?type=${type}`,
-            {
-                withCredentials: true,
-            },
-        )
+        await axios.get(`${BASE_URL}/user-dashboard/favorite-spots`, {
+            withCredentials: true,
+            params: type,
+        })
     ).data;
 }
 
@@ -168,10 +174,14 @@ export async function removeFavoriteSpot({
 }: RemoveFavoriteSpotProps): Promise<void> {
     return (
         await axios.patch(
-            `${BASE_URL}/user-dashboard/favorite-spots?type=${type}&spotId=${spotId}`,
+            `${BASE_URL}/user-dashboard/favorite-spots`,
             {},
             {
                 withCredentials: true,
+                params: {
+                    type,
+                    spotId,
+                },
             },
         )
     ).data;

--- a/venus/src/http/user-dashboard.ts
+++ b/venus/src/http/user-dashboard.ts
@@ -1,18 +1,15 @@
 import axios from "axios";
 import UserProfile from "../model/interface/account/profile/userProfile";
-import { SocialDto } from "../model/interface/account/social/socialDto";
-import { FavoriteSpot } from "../model/interface/account/favorite-spots/favoriteSpot";
 import { FavoriteSpotsListType } from "../model/enum/account/favorite-spots/favoriteSpotsListType";
 import { UserRelationEditType } from "../model/enum/account/social/userRelationEditType";
 import ExtendedUserProfile from "../model/interface/account/profile/extendedUserProfile";
-import DatedMediaGroup from "../model/interface/account/media/datedMediaGroup";
 import { DateSortType } from "../model/enum/account/photos/dateSortType";
-import DatedCommentsGroup from "../model/interface/account/comments/datedCommentsGroup";
 import UserEditData from "../model/interface/account/settings/userEditData";
 import UserData from "../model/interface/account/settings/userData";
 import { DatedMediaGroupPageDto } from "../model/interface/account/media/datedMediaGroupPageDto";
 import { FavoriteSpotPageDto } from "../model/interface/account/favorite-spots/favoriteSpotPageDto";
 import { DatedCommentsGroupPageDto } from "../model/interface/account/comments/datedCommentsGroupPageDto";
+import { SocialPageDto } from "../model/interface/account/social/socialPageDto";
 const BASE_URL = import.meta.env.VITE_MERKURY_BASE_URL;
 
 export async function getUserOwnProfile(): Promise<UserProfile> {
@@ -39,7 +36,7 @@ export async function getProfileForViewer(
 export async function getUserOwnFriends(
     page: number,
     size: number,
-): Promise<SocialDto[]> {
+): Promise<SocialPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/friends`, {
             withCredentials: true,
@@ -55,7 +52,7 @@ export async function getUserFriendsForViewer(
     username: string,
     page: number,
     size: number,
-): Promise<SocialDto[]> {
+): Promise<SocialPageDto> {
     return (
         await axios.get(
             `${BASE_URL}/public/user-dashboard/friends/${username}`,
@@ -96,7 +93,7 @@ export async function editUserFriends({
 export async function getUserOwnFollowed(
     page: number,
     size: number,
-): Promise<SocialDto[]> {
+): Promise<SocialPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/followed`, {
             withCredentials: true,
@@ -112,7 +109,7 @@ export async function getUserFollowedForViewer(
     username: string,
     page: number,
     size: number,
-): Promise<SocialDto[]> {
+): Promise<SocialPageDto> {
     return (
         await axios.get(
             `${BASE_URL}/public/user-dashboard/followed/${username}`,
@@ -129,7 +126,7 @@ export async function getUserFollowedForViewer(
 export async function getUserOwnFollowers(
     page: number,
     size: number,
-): Promise<SocialDto[]> {
+): Promise<SocialPageDto> {
     return (
         await axios.get(`${BASE_URL}/user-dashboard/followers`, {
             withCredentials: true,
@@ -145,7 +142,7 @@ export async function getUserFollowersForViewer(
     username: string,
     page: number,
     size: number,
-): Promise<SocialDto[]> {
+): Promise<SocialPageDto> {
     return (
         await axios.get(
             `${BASE_URL}/public/user-dashboard/followers/${username}`,

--- a/venus/src/model/interface/account/comments/datedCommentsGroupPageDto.ts
+++ b/venus/src/model/interface/account/comments/datedCommentsGroupPageDto.ts
@@ -1,0 +1,6 @@
+import DatedCommentsGroup from "./datedCommentsGroup";
+
+export interface DatedCommentsGroupPageDto {
+    items: DatedCommentsGroup[];
+    hasNext: boolean;
+}

--- a/venus/src/model/interface/account/favorite-spots/favoriteSpotPageDto.ts
+++ b/venus/src/model/interface/account/favorite-spots/favoriteSpotPageDto.ts
@@ -1,0 +1,6 @@
+import { FavoriteSpot } from "./favoriteSpot";
+
+export interface FavoriteSpotPageDto {
+    items: FavoriteSpot[];
+    hasNext: boolean;
+}

--- a/venus/src/model/interface/account/media/datedMediaGroupPageDto.ts
+++ b/venus/src/model/interface/account/media/datedMediaGroupPageDto.ts
@@ -1,0 +1,6 @@
+import DatedMediaGroup from "./datedMediaGroup";
+
+export interface DatedMediaGroupPageDto {
+    items: DatedMediaGroup[];
+    hasNext: boolean;
+}

--- a/venus/src/model/interface/account/social/socialPageDto.ts
+++ b/venus/src/model/interface/account/social/socialPageDto.ts
@@ -1,0 +1,6 @@
+import { SocialDto } from "./socialDto";
+
+export interface SocialPageDto {
+    items: SocialDto[];
+    hasNext: boolean;
+}

--- a/venus/src/pages/account/comments/Comments.tsx
+++ b/venus/src/pages/account/comments/Comments.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { getAllUserComments } from "../../../http/user-dashboard";
 import AccountTitle from "../components/AccountTitle";
 import AccountWrapper from "../components/AccountWrapper";
@@ -8,7 +8,7 @@ import CommentsList from "./components/CommentsList";
 import LoadingSpinner from "../../../components/loading-spinner/LoadingSpinner";
 import SortAndDateFilters from "../components/SortAndDateFilters";
 import { useDateSortFilter } from "../../../hooks/useDateSortFilter";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import useDispatchTyped from "../../../hooks/useDispatchTyped";
 import { notificationAction } from "../../../redux/notification";
 
@@ -16,12 +16,51 @@ export default function Comments() {
     const dispatch = useDispatchTyped();
     const { sortType, searchDate, handleSelectType, handleChangeDate } =
         useDateSortFilter();
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-    const { data, isLoading, isError } = useQuery({
+    const {
+        data,
+        isLoading,
+        isError,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery({
         queryKey: ["comments", sortType, searchDate.from, searchDate.to],
-        queryFn: () =>
-            getAllUserComments(searchDate.from, searchDate.to, sortType),
+        queryFn: ({ pageParam = 0 }) =>
+            getAllUserComments(
+                sortType,
+                searchDate.from,
+                searchDate.to,
+                pageParam,
+                10,
+            ),
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
+
+    const allItems = data?.pages.flatMap((page) => page.items);
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (
+                    entries[0].isIntersecting &&
+                    hasNextPage &&
+                    !isFetchingNextPage
+                ) {
+                    fetchNextPage();
+                }
+            },
+            { threshold: 1.0 },
+        );
+        observer.observe(loadMoreRef.current);
+        return () => {
+            observer.disconnect();
+        };
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
     useEffect(() => {
         if (isError) {
@@ -47,8 +86,8 @@ export default function Comments() {
             </div>
             {isLoading && <LoadingSpinner />}
             <ul className="space-y-5 md:mx-27">
-                {data?.length
-                    ? data?.map((d) => (
+                {allItems?.length
+                    ? allItems?.map((d) => (
                           <li
                               key={`${d.spotName}-${d.date}`}
                               className="flex flex-col space-y-5"
@@ -66,11 +105,13 @@ export default function Comments() {
                           </li>
                       ))
                     : null}
-                {!data?.length && !isLoading ? (
+                {!allItems?.length && !isLoading ? (
                     <p className="text-center text-lg">
                         You haven't added any comments.
                     </p>
                 ) : null}
+                <div ref={loadMoreRef} className="h-10" />
+                {isFetchingNextPage && <LoadingSpinner />}
             </ul>
         </AccountWrapper>
     );

--- a/venus/src/pages/account/comments/Comments.tsx
+++ b/venus/src/pages/account/comments/Comments.tsx
@@ -20,11 +20,7 @@ export default function Comments() {
     const { data, isLoading, isError } = useQuery({
         queryKey: ["comments", sortType, searchDate.from, searchDate.to],
         queryFn: () =>
-            getAllUserComments({
-                from: searchDate.from,
-                to: searchDate.to,
-                type: sortType,
-            }),
+            getAllUserComments(searchDate.from, searchDate.to, sortType),
     });
 
     useEffect(() => {

--- a/venus/src/pages/account/components/Media.tsx
+++ b/venus/src/pages/account/components/Media.tsx
@@ -9,6 +9,7 @@ import { DateSortType } from "../../../model/enum/account/photos/dateSortType";
 import { Dayjs } from "dayjs";
 import Photo from "../photos/components/Photo";
 import Movie from "../movies/components/Movie";
+import { MutableRefObject } from "react";
 
 interface MediaProps {
     variant: AccountWrapperType;
@@ -17,6 +18,8 @@ interface MediaProps {
     onDateChange: (value: Dayjs | null, key: "from" | "to") => void;
     isLoading: boolean;
     mediaList: DatedMediaGroup[] | undefined;
+    loadMoreRef: MutableRefObject<HTMLDivElement | null>;
+    isFetchingNextPage: boolean;
 }
 
 export default function Media({
@@ -26,6 +29,8 @@ export default function Media({
     onDateChange,
     searchDate,
     onSortChange,
+    loadMoreRef,
+    isFetchingNextPage,
 }: MediaProps) {
     return (
         <AccountWrapper variant={variant}>
@@ -72,6 +77,8 @@ export default function Media({
                         .
                     </p>
                 ) : null}
+                <div ref={loadMoreRef} className="h-10" />
+                {isFetchingNextPage && <LoadingSpinner />}
             </div>
         </AccountWrapper>
     );

--- a/venus/src/pages/account/favorite-spots/FavoriteSpots.tsx
+++ b/venus/src/pages/account/favorite-spots/FavoriteSpots.tsx
@@ -29,13 +29,13 @@ export default function FavoriteSpots() {
         useInfiniteQuery({
             queryKey: ["favorite-spots", selectedType],
             queryFn: ({ pageParam = 0 }) =>
-                getUserFavoriteSpots(selectedType, pageParam, 2),
+                getUserFavoriteSpots(selectedType, pageParam, 10),
             getNextPageParam: (lastPage, allPages) =>
                 lastPage.hasNext ? allPages.length : undefined,
             initialPageParam: 0,
         });
 
-    const favoriteSpots = data?.pages.flatMap((page) => page.items);
+    const allItems = data?.pages.flatMap((page) => page.items);
 
     const handleSetSelectedType = (type: FavoriteSpotsListType) => {
         setSelectedType(type);
@@ -82,8 +82,8 @@ export default function FavoriteSpots() {
             </div>
             {isLoading && <LoadingSpinner />}
             <div className="flex flex-col items-center space-y-5 lg:mx-27">
-                {favoriteSpots?.length
-                    ? favoriteSpots?.map((spot) => (
+                {allItems?.length
+                    ? allItems?.map((spot) => (
                           <FavoriteSpotTile
                               spot={spot}
                               key={spot.id}

--- a/venus/src/pages/account/movies/Movies.tsx
+++ b/venus/src/pages/account/movies/Movies.tsx
@@ -15,11 +15,7 @@ export default function Movies() {
     const { data, isLoading, isError } = useQuery({
         queryKey: ["movies", sortType, searchDate.from, searchDate.to],
         queryFn: () =>
-            getSortedUserMovies({
-                from: searchDate.from,
-                to: searchDate.to,
-                type: sortType,
-            }),
+            getSortedUserMovies(searchDate.from, searchDate.to, sortType),
     });
 
     useEffect(() => {

--- a/venus/src/pages/account/movies/Movies.tsx
+++ b/venus/src/pages/account/movies/Movies.tsx
@@ -1,8 +1,8 @@
 import useDispatchTyped from "../../../hooks/useDispatchTyped";
 import { useDateSortFilter } from "../../../hooks/useDateSortFilter";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { getSortedUserMovies } from "../../../http/user-dashboard";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { notificationAction } from "../../../redux/notification";
 import Media from "../components/Media";
 import { AccountWrapperType } from "../../../model/enum/account/accountWrapperType";
@@ -11,12 +11,51 @@ export default function Movies() {
     const dispatch = useDispatchTyped();
     const { sortType, searchDate, handleSelectType, handleChangeDate } =
         useDateSortFilter();
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-    const { data, isLoading, isError } = useQuery({
+    const {
+        data,
+        isLoading,
+        isError,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery({
         queryKey: ["movies", sortType, searchDate.from, searchDate.to],
-        queryFn: () =>
-            getSortedUserMovies(searchDate.from, searchDate.to, sortType),
+        queryFn: ({ pageParam = 0 }) =>
+            getSortedUserMovies(
+                sortType,
+                searchDate.from,
+                searchDate.to,
+                pageParam,
+                10,
+            ),
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
+
+    const allItems = data?.pages.flatMap((page) => page.items);
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (
+                    entries[0].isIntersecting &&
+                    hasNextPage &&
+                    !isFetchingNextPage
+                ) {
+                    fetchNextPage();
+                }
+            },
+            { threshold: 1.0 },
+        );
+        observer.observe(loadMoreRef.current);
+        return () => {
+            observer.disconnect();
+        };
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
     useEffect(() => {
         if (isError) {
@@ -36,7 +75,9 @@ export default function Movies() {
             onSortChange={handleSelectType}
             onDateChange={handleChangeDate}
             isLoading={isLoading}
-            mediaList={data}
+            mediaList={allItems}
+            loadMoreRef={loadMoreRef}
+            isFetchingNextPage={isFetchingNextPage}
         />
     );
 }

--- a/venus/src/pages/account/photos/Photos.tsx
+++ b/venus/src/pages/account/photos/Photos.tsx
@@ -1,8 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { getSortedUserPhotos } from "../../../http/user-dashboard";
 import { AccountWrapperType } from "../../../model/enum/account/accountWrapperType";
 import { useDateSortFilter } from "../../../hooks/useDateSortFilter";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { notificationAction } from "../../../redux/notification";
 import useDispatchTyped from "../../../hooks/useDispatchTyped";
 import Media from "../components/Media";
@@ -11,12 +11,51 @@ export default function Photos() {
     const dispatch = useDispatchTyped();
     const { sortType, searchDate, handleSelectType, handleChangeDate } =
         useDateSortFilter();
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-    const { data, isLoading, isError } = useQuery({
+    const {
+        data,
+        isLoading,
+        isError,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = useInfiniteQuery({
         queryKey: ["photos", sortType, searchDate.from, searchDate.to],
-        queryFn: () =>
-            getSortedUserPhotos(searchDate.from, searchDate.to, sortType),
+        queryFn: ({ pageParam = 0 }) =>
+            getSortedUserPhotos(
+                sortType,
+                searchDate.from,
+                searchDate.to,
+                pageParam,
+                12,
+            ),
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
+
+    const allItems = data?.pages.flatMap((page) => page.items);
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (
+                    entries[0].isIntersecting &&
+                    hasNextPage &&
+                    !isFetchingNextPage
+                ) {
+                    fetchNextPage();
+                }
+            },
+            { threshold: 1.0 },
+        );
+        observer.observe(loadMoreRef.current);
+        return () => {
+            observer.disconnect();
+        };
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
     useEffect(() => {
         if (isError) {
@@ -36,7 +75,9 @@ export default function Photos() {
             onSortChange={handleSelectType}
             onDateChange={handleChangeDate}
             isLoading={isLoading}
-            mediaList={data}
+            mediaList={allItems}
+            loadMoreRef={loadMoreRef}
+            isFetchingNextPage={isFetchingNextPage}
         />
     );
 }

--- a/venus/src/pages/account/photos/Photos.tsx
+++ b/venus/src/pages/account/photos/Photos.tsx
@@ -15,11 +15,7 @@ export default function Photos() {
     const { data, isLoading, isError } = useQuery({
         queryKey: ["photos", sortType, searchDate.from, searchDate.to],
         queryFn: () =>
-            getSortedUserPhotos({
-                from: searchDate.from,
-                to: searchDate.to,
-                type: sortType,
-            }),
+            getSortedUserPhotos(searchDate.from, searchDate.to, sortType),
     });
 
     useEffect(() => {

--- a/venus/src/pages/account/photos/Photos.tsx
+++ b/venus/src/pages/account/photos/Photos.tsx
@@ -28,7 +28,7 @@ export default function Photos() {
                 searchDate.from,
                 searchDate.to,
                 pageParam,
-                12,
+                2,
             ),
         getNextPageParam: (lastPage, allPages) =>
             lastPage.hasNext ? allPages.length : undefined,

--- a/venus/src/pages/account/social/Social.tsx
+++ b/venus/src/pages/account/social/Social.tsx
@@ -8,6 +8,8 @@ import { socialAction } from "../../../redux/social";
 import AccountTitle from "../components/AccountTitle";
 import AccountWrapper from "../components/AccountWrapper";
 import { AccountWrapperType } from "../../../model/enum/account/accountWrapperType";
+import { MutableRefObject } from "react";
+import LoadingSpinner from "../../../components/loading-spinner/LoadingSpinner";
 
 interface SocialProps {
     friends: SocialDto[];
@@ -15,6 +17,8 @@ interface SocialProps {
     followers: SocialDto[];
     photos?: SocialDto[];
     isSocialForViewer: boolean;
+    loadMoreRef: MutableRefObject<HTMLDivElement | null>;
+    isFetchingNextPage: boolean;
 }
 
 export default function Social({
@@ -23,6 +27,8 @@ export default function Social({
     followers,
     photos,
     isSocialForViewer,
+    loadMoreRef,
+    isFetchingNextPage,
 }: SocialProps) {
     const type = useSelectorTyped((state) => state.social.type);
     const dispatch = useDispatchTyped();
@@ -66,6 +72,8 @@ export default function Social({
                 type={type}
                 isSocialForViewer={isSocialForViewer}
             />
+            <div ref={loadMoreRef} className="h-10" />
+            {isFetchingNextPage && <LoadingSpinner />}
         </AccountWrapper>
     );
 }

--- a/venus/src/pages/account/social/SocialForViewer.tsx
+++ b/venus/src/pages/account/social/SocialForViewer.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import {
     getUserFollowedForViewer,
     getUserFollowersForViewer,
@@ -9,28 +9,114 @@ import { useParams } from "react-router-dom";
 import LoadingSpinner from "../../../components/loading-spinner/LoadingSpinner";
 import useSelectorTyped from "../../../hooks/useSelectorTyped";
 import { SocialListType } from "../../../model/enum/account/social/socialListType";
+import { useEffect, useRef } from "react";
 
 export default function SocialForViewer() {
     const { username } = useParams();
     const type = useSelectorTyped((state) => state.social.type);
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-    const { data: friends, isLoading: isLoadingFriends } = useQuery({
-        queryFn: () => getUserFriendsForViewer(username!),
+    const {
+        data: friends,
+        isLoading: isLoadingFriends,
+        fetchNextPage: fetchNextFriends,
+        hasNextPage: hasNextFriends,
+        isFetchingNextPage: isFetchingNextFriends,
+    } = useInfiniteQuery({
+        queryFn: ({ pageParam = 0 }) =>
+            getUserFriendsForViewer(username!, pageParam, 12),
         queryKey: ["friends", username],
         enabled: type === SocialListType.FRIENDS,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
 
-    const { data: followed, isLoading: isLoadingFollowed } = useQuery({
-        queryFn: () => getUserFollowedForViewer(username!),
+    const {
+        data: followed,
+        isLoading: isLoadingFollowed,
+        fetchNextPage: fetchNextFollowed,
+        hasNextPage: hasNextFollowed,
+        isFetchingNextPage: isFetchingNextFollowed,
+    } = useInfiniteQuery({
+        queryFn: ({ pageParam = 0 }) =>
+            getUserFollowedForViewer(username!, pageParam, 12),
         queryKey: ["followed", username],
         enabled: type === SocialListType.FOLLOWED,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
 
-    const { data: followers, isLoading: isLoadingFollowers } = useQuery({
-        queryFn: () => getUserFollowersForViewer(username!),
+    const {
+        data: followers,
+        isLoading: isLoadingFollowers,
+        fetchNextPage: fetchNextFollowers,
+        hasNextPage: hasNextFollowers,
+        isFetchingNextPage: isFetchingNextFollowers,
+    } = useInfiniteQuery({
+        queryFn: ({ pageParam = 0 }) =>
+            getUserFollowersForViewer(username!, pageParam, 12),
         queryKey: ["followers", username],
         enabled: type === SocialListType.FOLLOWERS,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
+
+    const allFriends = friends?.pages.flatMap((page) => page.items);
+    const allFollowed = followed?.pages.flatMap((page) => page.items);
+    const allFollowers = followers?.pages.flatMap((page) => page.items);
+
+    const isFetchingNextPage =
+        (type === SocialListType.FRIENDS && isFetchingNextFriends) ||
+        (type === SocialListType.FOLLOWED && isFetchingNextFollowed) ||
+        (type === SocialListType.FOLLOWERS && isFetchingNextFollowers);
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (!entries[0].isIntersecting) return;
+
+                switch (type) {
+                    case SocialListType.FRIENDS:
+                        if (hasNextFriends && !isFetchingNextFriends) {
+                            fetchNextFriends();
+                        }
+                        break;
+                    case SocialListType.FOLLOWED:
+                        if (hasNextFollowed && !isFetchingNextFollowed) {
+                            fetchNextFollowed();
+                        }
+                        break;
+                    case SocialListType.FOLLOWERS:
+                        if (hasNextFollowers && !isFetchingNextFollowers) {
+                            fetchNextFollowers();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            },
+            { threshold: 1.0 },
+        );
+
+        observer.observe(loadMoreRef.current);
+        return () => observer.disconnect();
+    }, [
+        type,
+        hasNextFriends,
+        isFetchingNextFriends,
+        fetchNextFriends,
+        hasNextFollowed,
+        isFetchingNextFollowed,
+        fetchNextFollowed,
+        hasNextFollowers,
+        isFetchingNextFollowers,
+        fetchNextFollowers,
+    ]);
 
     if (isLoadingFriends || isLoadingFollowed || isLoadingFollowers) {
         return <LoadingSpinner />;
@@ -38,12 +124,14 @@ export default function SocialForViewer() {
 
     return (
         <Social
-            friends={friends ?? []}
-            followed={followed ?? []}
-            followers={followers ?? []}
+            friends={allFriends ?? []}
+            followed={allFollowed ?? []}
+            followers={allFollowers ?? []}
             // TODO Photos będzie robione w innym zadaniu
             photos={[]}
             isSocialForViewer={true}
+            loadMoreRef={loadMoreRef}
+            isFetchingNextPage={isFetchingNextPage}
         />
     );
 }

--- a/venus/src/pages/account/social/UserOwnSocial.tsx
+++ b/venus/src/pages/account/social/UserOwnSocial.tsx
@@ -1,5 +1,5 @@
 import Social from "./Social";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import {
     getUserOwnFollowed,
     getUserOwnFollowers,
@@ -8,27 +8,110 @@ import {
 import useSelectorTyped from "../../../hooks/useSelectorTyped";
 import { SocialListType } from "../../../model/enum/account/social/socialListType";
 import LoadingSpinner from "../../../components/loading-spinner/LoadingSpinner";
+import { useEffect, useRef } from "react";
 
 export default function UserOwnSocial() {
     const type = useSelectorTyped((state) => state.social.type);
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
-    const { data: friends, isLoading: isLoadingFriends } = useQuery({
-        queryFn: getUserOwnFriends,
+    const {
+        data: friends,
+        isLoading: isLoadingFriends,
+        fetchNextPage: fetchNextFriends,
+        hasNextPage: hasNextFriends,
+        isFetchingNextPage: isFetchingNextFriends,
+    } = useInfiniteQuery({
+        queryFn: ({ pageParam = 0 }) => getUserOwnFriends(pageParam, 12),
         queryKey: ["friends"],
         enabled: type === SocialListType.FRIENDS,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
 
-    const { data: followed, isLoading: isLoadingFollowed } = useQuery({
-        queryFn: getUserOwnFollowed,
+    const {
+        data: followed,
+        isLoading: isLoadingFollowed,
+        fetchNextPage: fetchNextFollowed,
+        hasNextPage: hasNextFollowed,
+        isFetchingNextPage: isFetchingNextFollowed,
+    } = useInfiniteQuery({
         queryKey: ["followed"],
+        queryFn: ({ pageParam = 0 }) => getUserOwnFollowed(pageParam, 12),
         enabled: type === SocialListType.FOLLOWED,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
 
-    const { data: followers, isLoading: isLoadingFollowers } = useQuery({
-        queryFn: getUserOwnFollowers,
+    const {
+        data: followers,
+        isLoading: isLoadingFollowers,
+        fetchNextPage: fetchNextFollowers,
+        hasNextPage: hasNextFollowers,
+        isFetchingNextPage: isFetchingNextFollowers,
+    } = useInfiniteQuery({
         queryKey: ["followers"],
+        queryFn: ({ pageParam = 0 }) => getUserOwnFollowers(pageParam, 12),
         enabled: type === SocialListType.FOLLOWERS,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.hasNext ? allPages.length : undefined,
+        initialPageParam: 0,
     });
+
+    const allFriends = friends?.pages.flatMap((page) => page.items);
+    const allFollowed = followed?.pages.flatMap((page) => page.items);
+    const allFollowers = followers?.pages.flatMap((page) => page.items);
+
+    const isFetchingNextPage =
+        (type === SocialListType.FRIENDS && isFetchingNextFriends) ||
+        (type === SocialListType.FOLLOWED && isFetchingNextFollowed) ||
+        (type === SocialListType.FOLLOWERS && isFetchingNextFollowers);
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (!entries[0].isIntersecting) return;
+
+                switch (type) {
+                    case SocialListType.FRIENDS:
+                        if (hasNextFriends && !isFetchingNextFriends) {
+                            fetchNextFriends();
+                        }
+                        break;
+                    case SocialListType.FOLLOWED:
+                        if (hasNextFollowed && !isFetchingNextFollowed) {
+                            fetchNextFollowed();
+                        }
+                        break;
+                    case SocialListType.FOLLOWERS:
+                        if (hasNextFollowers && !isFetchingNextFollowers) {
+                            fetchNextFollowers();
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            },
+            { threshold: 1.0 },
+        );
+
+        observer.observe(loadMoreRef.current);
+        return () => observer.disconnect();
+    }, [
+        type,
+        hasNextFriends,
+        isFetchingNextFriends,
+        fetchNextFriends,
+        hasNextFollowed,
+        isFetchingNextFollowed,
+        fetchNextFollowed,
+        hasNextFollowers,
+        isFetchingNextFollowers,
+        fetchNextFollowers,
+    ]);
 
     if (isLoadingFriends || isLoadingFollowed || isLoadingFollowers) {
         return <LoadingSpinner />;
@@ -36,10 +119,12 @@ export default function UserOwnSocial() {
 
     return (
         <Social
-            friends={friends ?? []}
-            followed={followed ?? []}
-            followers={followers ?? []}
+            friends={allFriends ?? []}
+            followed={allFollowed ?? []}
+            followers={allFollowers ?? []}
             isSocialForViewer={false}
+            loadMoreRef={loadMoreRef}
+            isFetchingNextPage={isFetchingNextPage}
         />
     );
 }

--- a/venus/src/test/unit/user-dashboard/photos/Photos.test.jsx
+++ b/venus/src/test/unit/user-dashboard/photos/Photos.test.jsx
@@ -1,7 +1,7 @@
 import {
     QueryClient,
     QueryClientProvider,
-    useQuery,
+    useInfiniteQuery,
 } from "@tanstack/react-query";
 import { configureStore } from "@reduxjs/toolkit";
 import { accountSlice } from "../../../../redux/account";
@@ -17,11 +17,11 @@ const queryClient = new QueryClient();
 vi.mock("@tanstack/react-query", async () => {
     return {
         ...(await vi.importActual("@tanstack/react-query")),
-        useQuery: vi.fn(),
+        useInfiniteQuery: vi.fn(),
     };
 });
 
-const renderProfile = () => {
+const renderPhotos = () => {
     const store = configureStore({
         reducer: {
             account: accountSlice.reducer,
@@ -79,14 +79,34 @@ const mockPhotosData = [
 describe("Photos component unit tests", () => {
     describe("Photos display photos data correctly", () => {
         beforeEach(async () => {
-            useQuery.mockReturnValue({
-                data: mockPhotosData,
+            global.IntersectionObserver = class {
+                constructor(callback) {
+                    this.callback = callback;
+                }
+                observe() {
+                    this.callback([{ isIntersecting: true }]);
+                }
+                unobserve() {}
+                disconnect() {}
+            };
+            useInfiniteQuery.mockReturnValue({
+                data: {
+                    pages: [
+                        {
+                            items: mockPhotosData,
+                            hasNext: false,
+                        },
+                    ],
+                    pageParams: [0],
+                },
                 isLoading: false,
-                error: null,
+                hasNextPage: false,
+                fetchNextPage: vi.fn(),
+                isFetchingNextPage: false,
             });
 
             await act(async () => {
-                renderProfile();
+                renderPhotos();
             });
         });
 

--- a/venus/src/test/unit/user-dashboard/social/SocialForViewer.test.jsx
+++ b/venus/src/test/unit/user-dashboard/social/SocialForViewer.test.jsx
@@ -14,15 +14,26 @@ const queryClient = new QueryClient();
 vi.mock("@tanstack/react-query", async () => {
     return {
         ...(await vi.importActual("@tanstack/react-query")),
-        useQuery: vi.fn().mockReturnValue({
-            data: [],
+        useInfiniteQuery: vi.fn().mockReturnValue({
+            data: {
+                pages: [
+                    {
+                        items: [],
+                        hasNext: false,
+                    },
+                ],
+                pageParams: [0],
+            },
             isLoading: false,
             error: null,
+            hasNextPage: false,
+            fetchNextPage: vi.fn(),
+            isFetchingNextPage: false,
         }),
     };
 });
 
-const renderProfile = () => {
+const renderSocial = () => {
     const store = configureStore({
         reducer: {
             account: accountSlice.reducer,
@@ -49,7 +60,17 @@ const renderProfile = () => {
 
 describe("Social component unit tests", () => {
     beforeEach(() => {
-        renderProfile();
+        global.IntersectionObserver = class {
+            constructor(callback) {
+                this.callback = callback;
+            }
+            observe() {
+                this.callback([{ isIntersecting: true }]);
+            }
+            unobserve() {}
+            disconnect() {}
+        };
+        renderSocial();
     });
 
     describe("Should render menu buttons text", () => {

--- a/venus/src/test/unit/user-dashboard/social/UserOwnSocial.test.jsx
+++ b/venus/src/test/unit/user-dashboard/social/UserOwnSocial.test.jsx
@@ -37,15 +37,26 @@ vi.mock("@tanstack/react-query", async () => {
 
     return {
         ...(await vi.importActual("@tanstack/react-query")),
-        useQuery: vi.fn().mockReturnValue({
-            data: mockFriendsData,
+        useInfiniteQuery: vi.fn().mockReturnValue({
+            data: {
+                pages: [
+                    {
+                        items: mockFriendsData,
+                        hasNext: false,
+                    },
+                ],
+                pageParams: [0],
+            },
             isLoading: false,
             error: null,
+            hasNextPage: false,
+            fetchNextPage: vi.fn(),
+            isFetchingNextPage: false,
         }),
     };
 });
 
-const renderProfile = () => {
+const renderSocial = () => {
     const store = configureStore({
         reducer: {
             account: accountSlice.reducer,
@@ -73,7 +84,17 @@ const renderProfile = () => {
 describe("Social component unit tests", () => {
     describe("Social display friends data correctly", () => {
         beforeEach(() => {
-            renderProfile();
+            global.IntersectionObserver = class {
+                constructor(callback) {
+                    this.callback = callback;
+                }
+                observe() {
+                    this.callback([{ isIntersecting: true }]);
+                }
+                unobserve() {}
+                disconnect() {}
+            };
+            renderSocial();
         });
 
         describe("Should render all friend cards", () => {

--- a/venus/src/utils/account/favoriteSpotTypeFormater.ts
+++ b/venus/src/utils/account/favoriteSpotTypeFormater.ts
@@ -2,7 +2,7 @@ import { FavoriteSpotsListType } from "../../model/enum/account/favorite-spots/f
 
 export const formatSpotType = (type: FavoriteSpotsListType) => {
     return type
-        .toLowerCase()
+        ?.toLowerCase()
         .split("_")
         .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
         .join(" ");

--- a/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
@@ -5,15 +5,15 @@ import com.merkury.vulcanus.features.account.user.dashboard.UserDashboardService
 import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupPageDto;
 import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupPageDto;
 import com.merkury.vulcanus.model.dtos.account.profile.ExtendedUserProfileDto;
-import com.merkury.vulcanus.model.dtos.account.settings.UserDataDto;
-import com.merkury.vulcanus.model.dtos.account.social.SocialDto;
 import com.merkury.vulcanus.model.dtos.account.profile.UserProfileDto;
+import com.merkury.vulcanus.model.dtos.account.settings.UserDataDto;
 import com.merkury.vulcanus.model.dtos.account.settings.UserEditDataDto;
+import com.merkury.vulcanus.model.dtos.account.social.SocialPageDto;
 import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotPageDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
-import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserFriendStatus;
+import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,15 +38,15 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/friends")
-    public ResponseEntity<List<SocialDto>> getUserOwnFriends(@RequestParam(defaultValue = "0") int page,
-                                                             @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+    public ResponseEntity<SocialPageDto> getUserOwnFriends(@RequestParam(defaultValue = "0") int page,
+                                                           @RequestParam(defaultValue = "20") int size) {
         return ResponseEntity.ok(userDashboardService.getUserOwnFriends(page, size));
     }
 
     @GetMapping("/public/user-dashboard/friends/{targetUsername}")
-    public ResponseEntity<List<SocialDto>> getUserFriendsForViewer(@PathVariable String targetUsername,
-                                                                   @RequestParam(defaultValue = "0") int page,
-                                                                   @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+    public ResponseEntity<SocialPageDto> getUserFriendsForViewer(@PathVariable String targetUsername,
+                                                                 @RequestParam(defaultValue = "0") int page,
+                                                                 @RequestParam(defaultValue = "20") int size) {
         return ResponseEntity.ok(userDashboardService.getUserFriendsForViewer(targetUsername, page, size));
     }
 
@@ -65,28 +64,28 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/followers")
-    public ResponseEntity<List<SocialDto>> getUserOwnFollowers(@RequestParam(defaultValue = "0") int page,
-                                                               @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+    public ResponseEntity<SocialPageDto> getUserOwnFollowers(@RequestParam(defaultValue = "0") int page,
+                                                             @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
         return ResponseEntity.ok(userDashboardService.getUserOwnFollowers(page, size));
     }
 
     @GetMapping("/public/user-dashboard/followers/{targetUsername}")
-    public ResponseEntity<List<SocialDto>> getUserFollowersForViewer(@PathVariable String targetUsername,
-                                                                     @RequestParam(defaultValue = "0") int page,
-                                                                     @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+    public ResponseEntity<SocialPageDto> getUserFollowersForViewer(@PathVariable String targetUsername,
+                                                                   @RequestParam(defaultValue = "0") int page,
+                                                                   @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
         return ResponseEntity.ok(userDashboardService.getUserFollowersForViewer(targetUsername, page, size));
     }
 
     @GetMapping("/user-dashboard/followed")
-    public ResponseEntity<List<SocialDto>> getUserOwnFollowed(@RequestParam(defaultValue = "0") int page,
-                                                              @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+    public ResponseEntity<SocialPageDto> getUserOwnFollowed(@RequestParam(defaultValue = "0") int page,
+                                                            @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
         return ResponseEntity.ok(userDashboardService.getUserOwnFollowed(page, size));
     }
 
     @GetMapping("/public/user-dashboard/followed/{targetUsername}")
-    public ResponseEntity<List<SocialDto>> getUserFollowedForViewer(@PathVariable String targetUsername,
-                                                                    @RequestParam(defaultValue = "0") int page,
-                                                                    @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+    public ResponseEntity<SocialPageDto> getUserFollowedForViewer(@PathVariable String targetUsername,
+                                                                  @RequestParam(defaultValue = "0") int page,
+                                                                  @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
         return ResponseEntity.ok(userDashboardService.getUserFollowedForViewer(targetUsername, page, size));
     }
 
@@ -140,10 +139,10 @@ public class UserDashboardController {
 
     @GetMapping("/user-dashboard/movies")
     public ResponseEntity<DatedMediaGroupPageDto> getSortedUserMovies(@RequestParam DateSortType type,
-                                                                        @RequestParam(required = false) LocalDate from,
-                                                                        @RequestParam(required = false) LocalDate to,
-                                                                        @RequestParam(defaultValue = "0") int page,
-                                                                        @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
+                                                                      @RequestParam(required = false) LocalDate from,
+                                                                      @RequestParam(required = false) LocalDate to,
+                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                      @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
         return ResponseEntity.ok(userDashboardService.getSortedUserMovies(type, from, to, page, size));
     }
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
@@ -39,14 +39,14 @@ public class UserDashboardController {
 
     @GetMapping("/user-dashboard/friends")
     public ResponseEntity<SocialPageDto> getUserOwnFriends(@RequestParam(defaultValue = "0") int page,
-                                                           @RequestParam(defaultValue = "20") int size) {
+                                                           @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
         return ResponseEntity.ok(userDashboardService.getUserOwnFriends(page, size));
     }
 
     @GetMapping("/public/user-dashboard/friends/{targetUsername}")
     public ResponseEntity<SocialPageDto> getUserFriendsForViewer(@PathVariable String targetUsername,
                                                                  @RequestParam(defaultValue = "0") int page,
-                                                                 @RequestParam(defaultValue = "20") int size) {
+                                                                 @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
         return ResponseEntity.ok(userDashboardService.getUserFriendsForViewer(targetUsername, page, size));
     }
 

--- a/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
@@ -39,13 +39,16 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/friends")
-    public ResponseEntity<List<SocialDto>> getUserOwnFriends() throws UserNotFoundByUsernameException {
-        return ResponseEntity.ok(userDashboardService.getUserOwnFriends());
+    public ResponseEntity<List<SocialDto>> getUserOwnFriends(@RequestParam(defaultValue = "0") int page,
+                                                             @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+        return ResponseEntity.ok(userDashboardService.getUserOwnFriends(page, size));
     }
 
     @GetMapping("/public/user-dashboard/friends/{targetUsername}")
-    public ResponseEntity<List<SocialDto>> getUserFriendsForViewer(@PathVariable String targetUsername) throws UserNotFoundByUsernameException {
-        return ResponseEntity.ok(userDashboardService.getUserFriendsForViewer(targetUsername));
+    public ResponseEntity<List<SocialDto>> getUserFriendsForViewer(@PathVariable String targetUsername,
+                                                                   @RequestParam(defaultValue = "0") int page,
+                                                                   @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+        return ResponseEntity.ok(userDashboardService.getUserFriendsForViewer(targetUsername, page, size));
     }
 
     @PatchMapping("/user-dashboard/friends")
@@ -62,23 +65,29 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/followers")
-    public ResponseEntity<List<SocialDto>> getUserOwnFollowers() throws UserNotFoundByUsernameException {
-        return ResponseEntity.ok(userDashboardService.getUserOwnFollowers());
+    public ResponseEntity<List<SocialDto>> getUserOwnFollowers(@RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+        return ResponseEntity.ok(userDashboardService.getUserOwnFollowers(page, size));
     }
 
     @GetMapping("/public/user-dashboard/followers/{targetUsername}")
-    public ResponseEntity<List<SocialDto>> getUserFollowersForViewer(@PathVariable String targetUsername) throws UserNotFoundByUsernameException {
-        return ResponseEntity.ok(userDashboardService.getUserFollowersForViewer(targetUsername));
+    public ResponseEntity<List<SocialDto>> getUserFollowersForViewer(@PathVariable String targetUsername,
+                                                                     @RequestParam(defaultValue = "0") int page,
+                                                                     @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+        return ResponseEntity.ok(userDashboardService.getUserFollowersForViewer(targetUsername, page, size));
     }
 
     @GetMapping("/user-dashboard/followed")
-    public ResponseEntity<List<SocialDto>> getUserOwnFollowed() throws UserNotFoundByUsernameException {
-        return ResponseEntity.ok(userDashboardService.getUserOwnFollowed());
+    public ResponseEntity<List<SocialDto>> getUserOwnFollowed(@RequestParam(defaultValue = "0") int page,
+                                                              @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+        return ResponseEntity.ok(userDashboardService.getUserOwnFollowed(page, size));
     }
 
     @GetMapping("/public/user-dashboard/followed/{targetUsername}")
-    public ResponseEntity<List<SocialDto>> getUserFollowedForViewer(@PathVariable String targetUsername) throws UserNotFoundByUsernameException {
-        return ResponseEntity.ok(userDashboardService.getUserFollowedForViewer(targetUsername));
+    public ResponseEntity<List<SocialDto>> getUserFollowedForViewer(@PathVariable String targetUsername,
+                                                                    @RequestParam(defaultValue = "0") int page,
+                                                                    @RequestParam(defaultValue = "20") int size) throws UserNotFoundByUsernameException {
+        return ResponseEntity.ok(userDashboardService.getUserFollowedForViewer(targetUsername, page, size));
     }
 
     @PatchMapping("/user-dashboard/followed")
@@ -88,8 +97,10 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/favorite-spots")
-    public ResponseEntity<List<FavoriteSpotDto>> getAllUserFavoritesSpots(@RequestParam FavoriteSpotsListType type) {
-        return ResponseEntity.ok(userDashboardService.getUserFavoritesSpots(type));
+    public ResponseEntity<List<FavoriteSpotDto>> getAllUserFavoritesSpots(@RequestParam FavoriteSpotsListType type,
+                                                                          @RequestParam(defaultValue = "0") int page,
+                                                                          @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(userDashboardService.getUserFavoritesSpots(type, page, size));
     }
 
     @PatchMapping("/user-dashboard/favorite-spots")
@@ -99,13 +110,21 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/photos")
-    public ResponseEntity<List<DatedMediaGroupDto>> getSortedUserPhotos(@RequestParam DateSortType type, @RequestParam(required = false) LocalDate from, @RequestParam(required = false) LocalDate to) throws UnsupportedDateSortTypeException {
-        return ResponseEntity.ok(userDashboardService.getSortedUserPhotos(type, from, to));
+    public ResponseEntity<List<DatedMediaGroupDto>> getSortedUserPhotos(@RequestParam DateSortType type,
+                                                                        @RequestParam(required = false) LocalDate from,
+                                                                        @RequestParam(required = false) LocalDate to,
+                                                                        @RequestParam(defaultValue = "0") int page,
+                                                                        @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
+        return ResponseEntity.ok(userDashboardService.getSortedUserPhotos(type, from, to, page, size));
     }
 
     @GetMapping("user-dashboard/comments")
-    public ResponseEntity<List<DatedCommentsGroupDto>> getSortedUserComments(@RequestParam DateSortType type, @RequestParam(required = false) LocalDate from, @RequestParam(required = false) LocalDate to) throws UnsupportedDateSortTypeException {
-        return ResponseEntity.ok(userDashboardService.getSortedUserComments(type, from, to));
+    public ResponseEntity<List<DatedCommentsGroupDto>> getSortedUserComments(@RequestParam DateSortType type,
+                                                                             @RequestParam(required = false) LocalDate from,
+                                                                             @RequestParam(required = false) LocalDate to,
+                                                                             @RequestParam(defaultValue = "0") int page,
+                                                                             @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
+        return ResponseEntity.ok(userDashboardService.getSortedUserComments(type, from, to, page, size));
     }
 
     @PatchMapping("/user-dashboard/settings")
@@ -120,7 +139,11 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/movies")
-    public ResponseEntity<List<DatedMediaGroupDto>> getSortedUserMovies(@RequestParam DateSortType type, @RequestParam(required = false) LocalDate from, @RequestParam(required = false) LocalDate to) throws UnsupportedDateSortTypeException {
-        return ResponseEntity.ok(userDashboardService.getSortedUserMovies(type, from, to));
+    public ResponseEntity<List<DatedMediaGroupDto>> getSortedUserMovies(@RequestParam DateSortType type,
+                                                                        @RequestParam(required = false) LocalDate from,
+                                                                        @RequestParam(required = false) LocalDate to,
+                                                                        @RequestParam(defaultValue = "0") int page,
+                                                                        @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
+        return ResponseEntity.ok(userDashboardService.getSortedUserMovies(type, from, to, page, size));
     }
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/controllers/UserDashboardController.java
@@ -2,16 +2,16 @@ package com.merkury.vulcanus.controllers;
 
 import com.merkury.vulcanus.exception.exceptions.*;
 import com.merkury.vulcanus.features.account.user.dashboard.UserDashboardService;
-import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupDto;
-import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupDto;
+import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupPageDto;
+import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupPageDto;
 import com.merkury.vulcanus.model.dtos.account.profile.ExtendedUserProfileDto;
 import com.merkury.vulcanus.model.dtos.account.settings.UserDataDto;
 import com.merkury.vulcanus.model.dtos.account.social.SocialDto;
 import com.merkury.vulcanus.model.dtos.account.profile.UserProfileDto;
 import com.merkury.vulcanus.model.dtos.account.settings.UserEditDataDto;
+import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotPageDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
-import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserFriendStatus;
 import jakarta.servlet.http.HttpServletResponse;
@@ -97,9 +97,9 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/favorite-spots")
-    public ResponseEntity<List<FavoriteSpotDto>> getAllUserFavoritesSpots(@RequestParam FavoriteSpotsListType type,
-                                                                          @RequestParam(defaultValue = "0") int page,
-                                                                          @RequestParam(defaultValue = "10") int size) {
+    public ResponseEntity<FavoriteSpotPageDto> getAllUserFavoritesSpots(@RequestParam FavoriteSpotsListType type,
+                                                                        @RequestParam(defaultValue = "0") int page,
+                                                                        @RequestParam(defaultValue = "10") int size) {
         return ResponseEntity.ok(userDashboardService.getUserFavoritesSpots(type, page, size));
     }
 
@@ -110,20 +110,20 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/photos")
-    public ResponseEntity<List<DatedMediaGroupDto>> getSortedUserPhotos(@RequestParam DateSortType type,
-                                                                        @RequestParam(required = false) LocalDate from,
-                                                                        @RequestParam(required = false) LocalDate to,
-                                                                        @RequestParam(defaultValue = "0") int page,
-                                                                        @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
+    public ResponseEntity<DatedMediaGroupPageDto> getSortedUserPhotos(@RequestParam DateSortType type,
+                                                                      @RequestParam(required = false) LocalDate from,
+                                                                      @RequestParam(required = false) LocalDate to,
+                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                      @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
         return ResponseEntity.ok(userDashboardService.getSortedUserPhotos(type, from, to, page, size));
     }
 
     @GetMapping("user-dashboard/comments")
-    public ResponseEntity<List<DatedCommentsGroupDto>> getSortedUserComments(@RequestParam DateSortType type,
-                                                                             @RequestParam(required = false) LocalDate from,
-                                                                             @RequestParam(required = false) LocalDate to,
-                                                                             @RequestParam(defaultValue = "0") int page,
-                                                                             @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
+    public ResponseEntity<DatedCommentsGroupPageDto> getSortedUserComments(@RequestParam DateSortType type,
+                                                                           @RequestParam(required = false) LocalDate from,
+                                                                           @RequestParam(required = false) LocalDate to,
+                                                                           @RequestParam(defaultValue = "0") int page,
+                                                                           @RequestParam(defaultValue = "20") int size) throws UnsupportedDateSortTypeException {
         return ResponseEntity.ok(userDashboardService.getSortedUserComments(type, from, to, page, size));
     }
 
@@ -139,7 +139,7 @@ public class UserDashboardController {
     }
 
     @GetMapping("/user-dashboard/movies")
-    public ResponseEntity<List<DatedMediaGroupDto>> getSortedUserMovies(@RequestParam DateSortType type,
+    public ResponseEntity<DatedMediaGroupPageDto> getSortedUserMovies(@RequestParam DateSortType type,
                                                                         @RequestParam(required = false) LocalDate from,
                                                                         @RequestParam(required = false) LocalDate to,
                                                                         @RequestParam(defaultValue = "0") int page,

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
@@ -37,7 +37,7 @@ public class CommentsService {
         if (from == null && to == null) {
             comments = spotCommentRepository.findAllByAuthorUsername(username, pageable);
         } else if (from != null && to == null) {
-            comments = spotCommentRepository.findAllByAuthorUsernameAndPublishDateGreaterThanEqual(username, from.atTime(23, 59, 59), pageable);
+            comments = spotCommentRepository.findAllByAuthorUsernameAndPublishDateGreaterThanEqual(username, from.atStartOfDay(), pageable);
         } else if (from == null) {
             comments = spotCommentRepository.findAllByAuthorUsernameAndPublishDateLessThanEqual(username, to.atTime(23, 59, 59), pageable);
         } else {

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
@@ -2,10 +2,15 @@ package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.UnsupportedDateSortTypeException;
 import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupDto;
+import com.merkury.vulcanus.model.entities.spot.SpotComment;
 import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.CommentsMapper;
 import com.merkury.vulcanus.model.repositories.SpotCommentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -18,16 +23,30 @@ import java.util.stream.Collectors;
 public class CommentsService {
     private final SpotCommentRepository spotCommentRepository;
 
-    public List<DatedCommentsGroupDto> getSortedUserComments(String username, DateSortType type, LocalDate from, LocalDate to) throws UnsupportedDateSortTypeException {
-        return getAllUserComments(username, from, to).stream()
-                .sorted(getComparator(type))
-                .toList();
+    public List<DatedCommentsGroupDto> getSortedUserComments(String username, DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
+        return getAllUserComments(username, from, to, type, page, size);
     }
 
-    private List<DatedCommentsGroupDto> getAllUserComments(String username, LocalDate from, LocalDate to) {
-        return spotCommentRepository.findAllByAuthorUsername(username)
-                .stream()
-                .filter(comment -> isInDateRange(comment.getPublishDate().toLocalDate(), from, to))
+    /**
+     * 'publishDate' in SpotComment is a LocalDateTime, so we must pass LocalDateTime to the query.
+     * Here we convert 'from' to the end of the day (23:59:59) to ensure we include
+     * all comments published during that day and after.
+     */
+    private List<DatedCommentsGroupDto> getAllUserComments(String username, LocalDate from, LocalDate to, DateSortType sortType, int page, int size) throws UnsupportedDateSortTypeException {
+        Pageable pageable = PageRequest.of(page, size, getSpringSort(sortType));
+        Page<SpotComment> comments;
+
+        if (from == null && to == null) {
+            comments = spotCommentRepository.findAllByAuthorUsername(username, pageable);
+        } else if (from != null && to == null) {
+            comments = spotCommentRepository.findAllByAuthorUsernameAndPublishDateGreaterThanEqual(username, from.atTime(23, 59, 59), pageable);
+        } else if (from == null) {
+            comments = spotCommentRepository.findAllByAuthorUsernameAndPublishDateLessThanEqual(username, to.atTime(23, 59, 59), pageable);
+        } else {
+            comments = spotCommentRepository.findAllByAuthorUsernameAndPublishDateBetween(username, from.atTime(23, 59, 59), to.atTime(23, 59, 59), pageable);
+        }
+
+        return comments.stream()
                 .collect(Collectors.groupingBy(
                         comment ->
                                 new GroupKey(comment.getPublishDate().toLocalDate(), comment.getSpot().getName()),
@@ -40,18 +59,14 @@ public class CommentsService {
                 .toList();
     }
 
-    private record GroupKey(LocalDate date, String spotName) {
-    }
-
-    private boolean isInDateRange(LocalDate date, LocalDate from, LocalDate to) {
-        return (from == null || !date.isBefore(from)) && (to == null || !date.isAfter(to));
-    }
-
-    private Comparator<DatedCommentsGroupDto> getComparator(DateSortType type) throws UnsupportedDateSortTypeException {
+    private Sort getSpringSort(DateSortType type) throws UnsupportedDateSortTypeException {
         return switch (type) {
-            case DATE_ASCENDING -> Comparator.comparing(DatedCommentsGroupDto::date);
-            case DATE_DESCENDING -> Comparator.comparing(DatedCommentsGroupDto::date).reversed();
+            case DATE_ASCENDING -> Sort.by("publishDate").ascending();
+            case DATE_DESCENDING -> Sort.by("publishDate").descending();
             default -> throw new UnsupportedDateSortTypeException(type);
         };
+    }
+
+    private record GroupKey(LocalDate date, String spotName) {
     }
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
@@ -1,7 +1,6 @@
 package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.UnsupportedDateSortTypeException;
-import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupDto;
 import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupPageDto;
 import com.merkury.vulcanus.model.entities.spot.SpotComment;
 import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
@@ -15,8 +14,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/CommentsService.java
@@ -7,10 +7,7 @@ import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.CommentsMapper;
 import com.merkury.vulcanus.model.repositories.SpotCommentRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -32,7 +29,7 @@ public class CommentsService {
      */
     private DatedCommentsGroupPageDto getAllUserComments(String username, LocalDate from, LocalDate to, DateSortType sortType, int page, int size) throws UnsupportedDateSortTypeException {
         Pageable pageable = PageRequest.of(page, size, getSpringSort(sortType));
-        Page<SpotComment> comments;
+        Slice<SpotComment> comments;
 
         if (from == null && to == null) {
             comments = spotCommentRepository.findAllByAuthorUsername(username, pageable);

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
@@ -1,7 +1,6 @@
 package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.FavoriteSpotNotExistException;
-import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotDto;
 import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotPageDto;
 import com.merkury.vulcanus.model.entities.spot.FavoriteSpot;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
@@ -12,8 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
@@ -7,9 +7,9 @@ import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.FavoriteSpotMapper;
 import com.merkury.vulcanus.model.repositories.FavoriteSpotRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,7 +19,7 @@ public class FavoriteSpotService {
 
     public FavoriteSpotPageDto getUserFavoritesSpots(String username, FavoriteSpotsListType type, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<FavoriteSpot> favoriteSpots;
+        Slice<FavoriteSpot> favoriteSpots;
 
         if (type == FavoriteSpotsListType.ALL) {
             favoriteSpots = favoriteSpotRepository.findAllByUserUsername(username, pageable);

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
@@ -2,6 +2,7 @@ package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.FavoriteSpotNotExistException;
 import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotDto;
+import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotPageDto;
 import com.merkury.vulcanus.model.entities.spot.FavoriteSpot;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.FavoriteSpotMapper;
@@ -19,7 +20,7 @@ import java.util.List;
 public class FavoriteSpotService {
     private final FavoriteSpotRepository favoriteSpotRepository;
 
-    public List<FavoriteSpotDto> getUserFavoritesSpots(String username, FavoriteSpotsListType type, int page, int size) {
+    public FavoriteSpotPageDto getUserFavoritesSpots(String username, FavoriteSpotsListType type, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<FavoriteSpot> favoriteSpots;
 
@@ -29,9 +30,11 @@ public class FavoriteSpotService {
             favoriteSpots = favoriteSpotRepository.findAllByUserUsernameAndType(username, type, pageable);
         }
 
-        return favoriteSpots.stream()
+        var mappedFavoriteSpots = favoriteSpots.stream()
                 .map(FavoriteSpotMapper::toDto)
                 .toList();
+
+        return new FavoriteSpotPageDto(mappedFavoriteSpots, favoriteSpots.hasNext());
     }
 
     public void removeFavoriteSpot(String username, FavoriteSpotsListType type, Long spotId) throws FavoriteSpotNotExistException {

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotService.java
@@ -7,6 +7,9 @@ import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.FavoriteSpotMapper;
 import com.merkury.vulcanus.model.repositories.FavoriteSpotRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,17 +19,14 @@ import java.util.List;
 public class FavoriteSpotService {
     private final FavoriteSpotRepository favoriteSpotRepository;
 
-    public List<FavoriteSpotDto> getUserFavoritesSpots(String username, FavoriteSpotsListType type) {
-        List<FavoriteSpot> favoriteSpots;
+    public List<FavoriteSpotDto> getUserFavoritesSpots(String username, FavoriteSpotsListType type, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<FavoriteSpot> favoriteSpots;
 
         if (type == FavoriteSpotsListType.ALL) {
-            favoriteSpots = favoriteSpotRepository
-                    .findAllByUserUsername(username)
-                    .orElseGet(List::of);
+            favoriteSpots = favoriteSpotRepository.findAllByUserUsername(username, pageable);
         } else {
-            favoriteSpots = favoriteSpotRepository
-                    .findAllByUserUsernameAndType(username, type)
-                    .orElseGet(List::of);
+            favoriteSpots = favoriteSpotRepository.findAllByUserUsernameAndType(username, type, pageable);
         }
 
         return favoriteSpots.stream()
@@ -36,7 +36,7 @@ public class FavoriteSpotService {
 
     public void removeFavoriteSpot(String username, FavoriteSpotsListType type, Long spotId) throws FavoriteSpotNotExistException {
         var deleted = favoriteSpotRepository.removeFavoriteSpotByUserUsernameAndTypeAndSpotId(username, type, spotId);
-        if (deleted != 1){
+        if (deleted != 1) {
             throw new FavoriteSpotNotExistException();
         }
     }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FollowersService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FollowersService.java
@@ -20,18 +20,22 @@ public class FollowersService {
     private final UserEntityRepository userEntityRepository;
     private final UserEntityFetcher userEntityFetcher;
 
-    public List<SocialDto> getUserFollowers(String username) throws UserNotFoundByUsernameException {
+    public List<SocialDto> getUserFollowers(String username, int page, int size) throws UserNotFoundByUsernameException {
         return userEntityFetcher.getByUsername(username)
                 .getFollowers()
                 .stream()
+                .skip((long) page * size)
+                .limit(size)
                 .map(SocialMapper::toDto)
                 .toList();
     }
 
-    public List<SocialDto> getUserFollowed(String username) throws UserNotFoundByUsernameException {
+    public List<SocialDto> getUserFollowed(String username, int page, int size) throws UserNotFoundByUsernameException {
         return userEntityFetcher.getByUsername(username)
                 .getFollowed()
                 .stream()
+                .skip((long) page * size)
+                .limit(size)
                 .map(SocialMapper::toDto)
                 .toList();
     }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FollowersService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FollowersService.java
@@ -1,18 +1,17 @@
 package com.merkury.vulcanus.features.account.user.dashboard;
 
+import com.merkury.vulcanus.exception.exceptions.UnsupportedEditUserFriendsTypeException;
 import com.merkury.vulcanus.exception.exceptions.UserAlreadyFollowedException;
 import com.merkury.vulcanus.exception.exceptions.UserNotFollowedException;
-import com.merkury.vulcanus.exception.exceptions.UnsupportedEditUserFriendsTypeException;
 import com.merkury.vulcanus.exception.exceptions.UserNotFoundByUsernameException;
-import com.merkury.vulcanus.model.dtos.account.social.SocialDto;
+import com.merkury.vulcanus.model.dtos.account.social.SocialPageDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.SocialMapper;
 import com.merkury.vulcanus.model.repositories.UserEntityRepository;
 import com.merkury.vulcanus.utils.user.dashboard.UserEntityFetcher;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,25 +19,28 @@ public class FollowersService {
     private final UserEntityRepository userEntityRepository;
     private final UserEntityFetcher userEntityFetcher;
 
-    public List<SocialDto> getUserFollowers(String username, int page, int size) throws UserNotFoundByUsernameException {
-        return userEntityFetcher.getByUsername(username)
-                .getFollowers()
-                .stream()
-                .skip((long) page * size)
-                .limit(size)
-                .map(SocialMapper::toDto)
-                .toList();
+    public SocialPageDto getUserFollowers(String username, int page, int size) throws UserNotFoundByUsernameException {
+        var followersPage = userEntityRepository.findFollowersByFollowedUsername(username, PageRequest.of(page, size));
+        if (followersPage.isEmpty()) {
+            throw new UserNotFoundByUsernameException(username);
+        }
+
+        var mappedFollowers = followersPage.stream().map(SocialMapper::toDto).toList();
+
+        return new SocialPageDto(mappedFollowers, followersPage.hasNext());
     }
 
-    public List<SocialDto> getUserFollowed(String username, int page, int size) throws UserNotFoundByUsernameException {
-        return userEntityFetcher.getByUsername(username)
-                .getFollowed()
-                .stream()
-                .skip((long) page * size)
-                .limit(size)
-                .map(SocialMapper::toDto)
-                .toList();
+    public SocialPageDto getUserFollowed(String username, int page, int size) throws UserNotFoundByUsernameException {
+        var followedPage = userEntityRepository.findFollowedByFollowersUsername(username, PageRequest.of(page, size));
+        if (followedPage.isEmpty()) {
+            throw new UserNotFoundByUsernameException(username);
+        }
+
+        var mappedFollowed = followedPage.stream().map(SocialMapper::toDto).toList();
+
+        return new SocialPageDto(mappedFollowed, followedPage.hasNext());
     }
+
 
     public void editUserFollowed(String username, String followedUsername, UserRelationEditType type) throws UserNotFoundByUsernameException, UserAlreadyFollowedException, UserNotFollowedException, UnsupportedEditUserFriendsTypeException {
         switch (type) {

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FriendsService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/FriendsService.java
@@ -25,8 +25,12 @@ public class FriendsService {
     private final UserEntityFetcher userEntityFetcher;
     private final FriendshipRepository friendshipRepository;
 
-    public SocialPageDto getUserFriends(String username, int page, int size) {
+    public SocialPageDto getUserFriends(String username, int page, int size) throws UserNotFoundByUsernameException {
         var friendsPage = friendshipRepository.findAllByUserUsername(username, PageRequest.of(page, size));
+
+        if (friendsPage.isEmpty()) {
+            throw new UserNotFoundByUsernameException(username);
+        }
 
         var mappedFriends = friendsPage.stream().map(SocialMapper::toDto).toList();
 

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/MediaService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/MediaService.java
@@ -8,6 +8,10 @@ import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
 import com.merkury.vulcanus.model.mappers.user.dashboard.MediaMapper;
 import com.merkury.vulcanus.model.repositories.SpotMediaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -20,29 +24,28 @@ import java.util.stream.Collectors;
 public class MediaService {
     private final SpotMediaRepository spotMediaRepository;
 
-    public List<DatedMediaGroupDto> getSortedUserPhotos(String username, DateSortType type, LocalDate from, LocalDate to) throws UnsupportedDateSortTypeException {
-        return getAllUserMedia(username, from, to, GenericMediaType.PHOTO).stream()
-                .sorted(getComparator(type))
-                .toList();
+    public List<DatedMediaGroupDto> getSortedUserPhotos(String username, DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
+        return getAllUserMedia(username, from, to, GenericMediaType.PHOTO, type, page, size);
     }
 
-    public List<DatedMediaGroupDto> getSortedUserMovies(String username, DateSortType type, LocalDate from, LocalDate to) throws UnsupportedDateSortTypeException {
-        return getAllUserMedia(username, from, to, GenericMediaType.VIDEO).stream()
-                .sorted(getComparator(type))
-                .toList();
+    public List<DatedMediaGroupDto> getSortedUserMovies(String username, DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
+        return getAllUserMedia(username, from, to, GenericMediaType.VIDEO, type, page, size);
     }
 
-    private List<DatedMediaGroupDto> getAllUserMedia(String username, LocalDate from, LocalDate to, GenericMediaType type) {
-        List<SpotMedia> media;
+    private List<DatedMediaGroupDto> getAllUserMedia(String username, LocalDate from, LocalDate to, GenericMediaType type, DateSortType sortType, int page, int size) throws UnsupportedDateSortTypeException {
+        Pageable pageable = PageRequest.of(page, size, getSpringSort(sortType));
+        Page<SpotMedia> media;
+
         if (from == null && to == null) {
-            media = spotMediaRepository.findAllByAuthorUsernameAndGenericMediaType(username, type);
+            media = spotMediaRepository.findAllByAuthorUsernameAndGenericMediaType(username, type, pageable);
         } else if (from != null && to == null) {
-            media = spotMediaRepository.findByAuthorUsernameAndGenericMediaTypeAndAddDateGreaterThanEqual(username, type, from);
+            media = spotMediaRepository.findByAuthorUsernameAndGenericMediaTypeAndAddDateGreaterThanEqual(username, type, from, pageable);
         } else if (from == null) {
-            media = spotMediaRepository.findByAuthorUsernameAndGenericMediaTypeAndAddDateLessThanEqual(username, type, to);
+            media = spotMediaRepository.findByAuthorUsernameAndGenericMediaTypeAndAddDateLessThanEqual(username, type, to, pageable);
         } else {
-            media = spotMediaRepository.findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(username, type, from, to);
+            media = spotMediaRepository.findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(username, type, from, to, pageable);
         }
+
         return media.stream()
                 .collect(Collectors.groupingBy(
                         SpotMedia::getAddDate,
@@ -52,10 +55,10 @@ public class MediaService {
                 .toList();
     }
 
-    private Comparator<DatedMediaGroupDto> getComparator(DateSortType type) throws UnsupportedDateSortTypeException {
+    private Sort getSpringSort(DateSortType type) throws UnsupportedDateSortTypeException {
         return switch (type) {
-            case DATE_ASCENDING -> Comparator.comparing(DatedMediaGroupDto::date);
-            case DATE_DESCENDING -> Comparator.comparing(DatedMediaGroupDto::date).reversed();
+            case DATE_ASCENDING -> Sort.by("addDate").ascending();
+            case DATE_DESCENDING -> Sort.by("addDate").descending();
             default -> throw new UnsupportedDateSortTypeException(type);
         };
     }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/MediaService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/MediaService.java
@@ -1,7 +1,6 @@
 package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.UnsupportedDateSortTypeException;
-import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupDto;
 import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupPageDto;
 import com.merkury.vulcanus.model.entities.spot.SpotMedia;
 import com.merkury.vulcanus.model.enums.GenericMediaType;
@@ -16,8 +15,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
 import java.util.stream.Collectors;
 
 @Service

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
@@ -4,15 +4,15 @@ import com.merkury.vulcanus.exception.exceptions.*;
 import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupPageDto;
 import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupPageDto;
 import com.merkury.vulcanus.model.dtos.account.profile.ExtendedUserProfileDto;
-import com.merkury.vulcanus.model.dtos.account.settings.UserDataDto;
-import com.merkury.vulcanus.model.dtos.account.social.SocialDto;
 import com.merkury.vulcanus.model.dtos.account.profile.UserProfileDto;
+import com.merkury.vulcanus.model.dtos.account.settings.UserDataDto;
 import com.merkury.vulcanus.model.dtos.account.settings.UserEditDataDto;
+import com.merkury.vulcanus.model.dtos.account.social.SocialPageDto;
 import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotPageDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
-import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserFriendStatus;
+import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
 import com.merkury.vulcanus.security.CustomUserDetailsService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,6 @@ import org.springframework.security.authentication.InsufficientAuthenticationExc
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -55,12 +54,12 @@ public class UserDashboardService {
     }
 
 
-    public List<SocialDto> getUserOwnFriends(int page, int size) throws UserNotFoundByUsernameException {
+    public SocialPageDto getUserOwnFriends(int page, int size) {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return friendsService.getUserFriends(username, page, size);
     }
 
-    public List<SocialDto> getUserFriendsForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
+    public SocialPageDto getUserFriendsForViewer(String targetUsername, int page, int size) {
         return friendsService.getUserFriends(targetUsername, page, size);
     }
 
@@ -74,21 +73,21 @@ public class UserDashboardService {
         friendsService.changeUserFriendsStatus(username, friendUsername, status);
     }
 
-    public List<SocialDto> getUserOwnFollowers(int page, int size) throws UserNotFoundByUsernameException {
+    public SocialPageDto getUserOwnFollowers(int page, int size) throws UserNotFoundByUsernameException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return followersService.getUserFollowers(username, page, size);
     }
 
-    public List<SocialDto> getUserFollowersForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
+    public SocialPageDto getUserFollowersForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
         return followersService.getUserFollowers(targetUsername, page, size);
     }
 
-    public List<SocialDto> getUserOwnFollowed(int page, int size) throws UserNotFoundByUsernameException {
+    public SocialPageDto getUserOwnFollowed(int page, int size) throws UserNotFoundByUsernameException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return followersService.getUserFollowed(username, page, size);
     }
 
-    public List<SocialDto> getUserFollowedForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
+    public SocialPageDto getUserFollowedForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
         return followersService.getUserFollowed(targetUsername, page, size);
     }
 

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
@@ -1,16 +1,16 @@
 package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.*;
-import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupDto;
-import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupDto;
+import com.merkury.vulcanus.model.dtos.account.comments.DatedCommentsGroupPageDto;
+import com.merkury.vulcanus.model.dtos.account.media.DatedMediaGroupPageDto;
 import com.merkury.vulcanus.model.dtos.account.profile.ExtendedUserProfileDto;
 import com.merkury.vulcanus.model.dtos.account.settings.UserDataDto;
 import com.merkury.vulcanus.model.dtos.account.social.SocialDto;
 import com.merkury.vulcanus.model.dtos.account.profile.UserProfileDto;
 import com.merkury.vulcanus.model.dtos.account.settings.UserEditDataDto;
+import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotPageDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.DateSortType;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserRelationEditType;
-import com.merkury.vulcanus.model.dtos.account.spots.FavoriteSpotDto;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.enums.user.dashboard.UserFriendStatus;
 import com.merkury.vulcanus.security.CustomUserDetailsService;
@@ -97,7 +97,7 @@ public class UserDashboardService {
         followersService.editUserFollowed(username, followedUsername, type);
     }
 
-    public List<FavoriteSpotDto> getUserFavoritesSpots(FavoriteSpotsListType type, int page, int size) {
+    public FavoriteSpotPageDto getUserFavoritesSpots(FavoriteSpotsListType type, int page, int size) {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return favoriteSpotService.getUserFavoritesSpots(username, type, page, size);
     }
@@ -107,12 +107,12 @@ public class UserDashboardService {
         favoriteSpotService.removeFavoriteSpot(username, type, spotId);
     }
 
-    public List<DatedMediaGroupDto> getSortedUserPhotos(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
+    public DatedMediaGroupPageDto getSortedUserPhotos(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return mediaService.getSortedUserPhotos(username, type, from, to, page, size);
     }
 
-    public List<DatedCommentsGroupDto> getSortedUserComments(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
+    public DatedCommentsGroupPageDto getSortedUserComments(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return commentsService.getSortedUserComments(username, type, from, to, page, size);
     }
@@ -127,7 +127,7 @@ public class UserDashboardService {
         return settingsService.getUserData(username);
     }
 
-    public List<DatedMediaGroupDto> getSortedUserMovies(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
+    public DatedMediaGroupPageDto getSortedUserMovies(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return mediaService.getSortedUserMovies(username, type, from, to, page, size);
     }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
@@ -54,12 +54,12 @@ public class UserDashboardService {
     }
 
 
-    public SocialPageDto getUserOwnFriends(int page, int size) {
+    public SocialPageDto getUserOwnFriends(int page, int size) throws UserNotFoundByUsernameException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
         return friendsService.getUserFriends(username, page, size);
     }
 
-    public SocialPageDto getUserFriendsForViewer(String targetUsername, int page, int size) {
+    public SocialPageDto getUserFriendsForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
         return friendsService.getUserFriends(targetUsername, page, size);
     }
 

--- a/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/features/account/user/dashboard/UserDashboardService.java
@@ -55,13 +55,13 @@ public class UserDashboardService {
     }
 
 
-    public List<SocialDto> getUserOwnFriends() throws UserNotFoundByUsernameException {
+    public List<SocialDto> getUserOwnFriends(int page, int size) throws UserNotFoundByUsernameException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return friendsService.getUserFriends(username);
+        return friendsService.getUserFriends(username, page, size);
     }
 
-    public List<SocialDto> getUserFriendsForViewer(String targetUsername) throws UserNotFoundByUsernameException {
-        return friendsService.getUserFriends(targetUsername);
+    public List<SocialDto> getUserFriendsForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
+        return friendsService.getUserFriends(targetUsername, page, size);
     }
 
     public void editUserFriends(String friendUsername, UserRelationEditType type) throws UserNotFoundByUsernameException, FriendshipAlreadyExistException, FriendshipNotExistException, UnsupportedEditUserFriendsTypeException {
@@ -74,22 +74,22 @@ public class UserDashboardService {
         friendsService.changeUserFriendsStatus(username, friendUsername, status);
     }
 
-    public List<SocialDto> getUserOwnFollowers() throws UserNotFoundByUsernameException {
+    public List<SocialDto> getUserOwnFollowers(int page, int size) throws UserNotFoundByUsernameException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return followersService.getUserFollowers(username);
+        return followersService.getUserFollowers(username, page, size);
     }
 
-    public List<SocialDto> getUserFollowersForViewer(String targetUsername) throws UserNotFoundByUsernameException {
-        return followersService.getUserFollowers(targetUsername);
+    public List<SocialDto> getUserFollowersForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
+        return followersService.getUserFollowers(targetUsername, page, size);
     }
 
-    public List<SocialDto> getUserOwnFollowed() throws UserNotFoundByUsernameException {
+    public List<SocialDto> getUserOwnFollowed(int page, int size) throws UserNotFoundByUsernameException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return followersService.getUserFollowed(username);
+        return followersService.getUserFollowed(username, page, size);
     }
 
-    public List<SocialDto> getUserFollowedForViewer(String targetUsername) throws UserNotFoundByUsernameException {
-        return followersService.getUserFollowed(targetUsername);
+    public List<SocialDto> getUserFollowedForViewer(String targetUsername, int page, int size) throws UserNotFoundByUsernameException {
+        return followersService.getUserFollowed(targetUsername, page, size);
     }
 
     public void editUserFollowed(String followedUsername, UserRelationEditType type) throws UserNotFoundByUsernameException, UserAlreadyFollowedException, UserNotFollowedException, UnsupportedEditUserFriendsTypeException {
@@ -97,9 +97,9 @@ public class UserDashboardService {
         followersService.editUserFollowed(username, followedUsername, type);
     }
 
-    public List<FavoriteSpotDto> getUserFavoritesSpots(FavoriteSpotsListType type) {
+    public List<FavoriteSpotDto> getUserFavoritesSpots(FavoriteSpotsListType type, int page, int size) {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return favoriteSpotService.getUserFavoritesSpots(username, type);
+        return favoriteSpotService.getUserFavoritesSpots(username, type, page, size);
     }
 
     public void removeFavoriteSpot(FavoriteSpotsListType type, Long spotId) throws FavoriteSpotNotExistException {
@@ -107,14 +107,14 @@ public class UserDashboardService {
         favoriteSpotService.removeFavoriteSpot(username, type, spotId);
     }
 
-    public List<DatedMediaGroupDto> getSortedUserPhotos(DateSortType type, LocalDate from, LocalDate to) throws UnsupportedDateSortTypeException {
+    public List<DatedMediaGroupDto> getSortedUserPhotos(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return mediaService.getSortedUserPhotos(username, type, from, to);
+        return mediaService.getSortedUserPhotos(username, type, from, to, page, size);
     }
 
-    public List<DatedCommentsGroupDto> getSortedUserComments(DateSortType type, LocalDate from, LocalDate to) throws UnsupportedDateSortTypeException {
+    public List<DatedCommentsGroupDto> getSortedUserComments(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return commentsService.getSortedUserComments(username, type, from, to);
+        return commentsService.getSortedUserComments(username, type, from, to, page, size);
     }
 
     public void editUserSettings(HttpServletResponse response, UserEditDataDto userEdit) throws UserNotFoundByUsernameException, UserNotFoundException, ExternalProviderAccountException, UnsupportedUserSettingsType, EmailTakenException, SamePasswordException, SameEmailException, InvalidPasswordException, UsernameTakenException, SameUsernameException {
@@ -127,8 +127,8 @@ public class UserDashboardService {
         return settingsService.getUserData(username);
     }
 
-    public List<DatedMediaGroupDto> getSortedUserMovies(DateSortType type, LocalDate from, LocalDate to) throws UnsupportedDateSortTypeException {
+    public List<DatedMediaGroupDto> getSortedUserMovies(DateSortType type, LocalDate from, LocalDate to, int page, int size) throws UnsupportedDateSortTypeException {
         var username = customUserDetailsService.loadUserDetailsFromSecurityContext().getUsername();
-        return mediaService.getSortedUserMovies(username, type, from, to);
+        return mediaService.getSortedUserMovies(username, type, from, to, page, size);
     }
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/comments/DatedCommentsGroupPageDto.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/comments/DatedCommentsGroupPageDto.java
@@ -1,0 +1,6 @@
+package com.merkury.vulcanus.model.dtos.account.comments;
+
+import java.util.List;
+
+public record DatedCommentsGroupPageDto(List<DatedCommentsGroupDto> items, boolean hasNext) {
+}

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/media/DatedMediaGroupPageDto.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/media/DatedMediaGroupPageDto.java
@@ -1,0 +1,7 @@
+package com.merkury.vulcanus.model.dtos.account.media;
+
+import java.util.List;
+
+public record DatedMediaGroupPageDto(List<DatedMediaGroupDto> items,
+                                     boolean hasNext) {
+}

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/social/SocialPageDto.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/social/SocialPageDto.java
@@ -1,0 +1,6 @@
+package com.merkury.vulcanus.model.dtos.account.social;
+
+import java.util.List;
+
+public record SocialPageDto(List<SocialDto> items, boolean hasNext) {
+}

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/spots/FavoriteSpotPageDto.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/account/spots/FavoriteSpotPageDto.java
@@ -1,0 +1,6 @@
+package com.merkury.vulcanus.model.dtos.account.spots;
+
+import java.util.List;
+
+public record FavoriteSpotPageDto(List<FavoriteSpotDto> items, boolean hasNext) {
+}

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/interfaces/FriendView.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/interfaces/FriendView.java
@@ -1,0 +1,11 @@
+package com.merkury.vulcanus.model.interfaces;
+
+public interface FriendView {
+    UserInfo getFriend();
+
+    interface UserInfo {
+        String getUsername();
+
+        String getProfilePhoto();
+    }
+}

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/mappers/user/dashboard/SocialMapper.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/mappers/user/dashboard/SocialMapper.java
@@ -3,23 +3,31 @@ package com.merkury.vulcanus.model.mappers.user.dashboard;
 import com.merkury.vulcanus.model.dtos.account.social.SocialDto;
 import com.merkury.vulcanus.model.entities.Friendship;
 import com.merkury.vulcanus.model.entities.UserEntity;
+import com.merkury.vulcanus.model.interfaces.FriendView;
 import jakarta.validation.constraints.NotNull;
 
 public class SocialMapper {
     private SocialMapper() {
     }
 
-    public static SocialDto toDto(@NotNull Friendship friendship){
+    public static SocialDto toDto(@NotNull Friendship friendship) {
         return SocialDto.builder()
                 .username(friendship.getFriend().getUsername())
                 .profilePhoto(friendship.getFriend().getProfilePhoto())
                 .build();
     }
 
-    public static SocialDto toDto(@NotNull UserEntity userEntity){
+    public static SocialDto toDto(@NotNull UserEntity userEntity) {
         return SocialDto.builder()
                 .username(userEntity.getUsername())
                 .profilePhoto(userEntity.getProfilePhoto())
+                .build();
+    }
+
+    public static SocialDto toDto(@NotNull FriendView friendView) {
+        return SocialDto.builder()
+                .username(friendView.getFriend().getUsername())
+                .profilePhoto(friendView.getFriend().getProfilePhoto())
                 .build();
     }
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FavoriteSpotRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FavoriteSpotRepository.java
@@ -3,17 +3,17 @@ package com.merkury.vulcanus.model.repositories;
 import com.merkury.vulcanus.model.entities.spot.FavoriteSpot;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import jakarta.transaction.Transactional;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 
 public interface FavoriteSpotRepository extends JpaRepository<FavoriteSpot, Long> {
-    Page<FavoriteSpot> findAllByUserUsername(String username, Pageable pageable);
+    Slice<FavoriteSpot> findAllByUserUsername(String username, Pageable pageable);
 
-    Page<FavoriteSpot> findAllByUserUsernameAndType(String username, FavoriteSpotsListType type, Pageable pageable);
+    Slice<FavoriteSpot> findAllByUserUsernameAndType(String username, FavoriteSpotsListType type, Pageable pageable);
 
     @Transactional
     @Modifying

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FavoriteSpotRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FavoriteSpotRepository.java
@@ -3,16 +3,18 @@ package com.merkury.vulcanus.model.repositories;
 import com.merkury.vulcanus.model.entities.spot.FavoriteSpot;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import jakarta.transaction.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
-import java.util.Optional;
 
 public interface FavoriteSpotRepository extends JpaRepository<FavoriteSpot, Long> {
-    Optional<List<FavoriteSpot>> findAllByUserUsername(String username);
-    Optional<List<FavoriteSpot>> findAllByUserUsernameAndType(String username, FavoriteSpotsListType type);
+    Page<FavoriteSpot> findAllByUserUsername(String username, Pageable pageable);
+
+    Page<FavoriteSpot> findAllByUserUsernameAndType(String username, FavoriteSpotsListType type, Pageable pageable);
+
     @Transactional
     @Modifying
     @Query("DELETE FROM favorite_spots fs WHERE fs.user.username = :username AND fs.type = :type AND fs.spot.id = :spotId")

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FriendshipRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FriendshipRepository.java
@@ -1,0 +1,13 @@
+package com.merkury.vulcanus.model.repositories;
+
+import com.merkury.vulcanus.model.entities.Friendship;
+import com.merkury.vulcanus.model.interfaces.FriendView;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+    Page<FriendView> findAllByUserUsername(String username, Pageable pageable);
+}

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FriendshipRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/FriendshipRepository.java
@@ -2,12 +2,12 @@ package com.merkury.vulcanus.model.repositories;
 
 import com.merkury.vulcanus.model.entities.Friendship;
 import com.merkury.vulcanus.model.interfaces.FriendView;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
-    Page<FriendView> findAllByUserUsername(String username, Pageable pageable);
+    Slice<FriendView> findAllByUserUsername(String username, Pageable pageable);
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotCommentRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotCommentRepository.java
@@ -4,6 +4,7 @@ import com.merkury.vulcanus.model.entities.spot.SpotComment;
 import com.merkury.vulcanus.model.entities.UserEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -23,11 +24,11 @@ public interface SpotCommentRepository extends JpaRepository<SpotComment, Long> 
 
     List<SpotComment> findBySpotId(Long spotId);
 
-    Page<SpotComment> findAllByAuthorUsername(String username, Pageable pageable);
+    Slice<SpotComment> findAllByAuthorUsername(String username, Pageable pageable);
 
-    Page<SpotComment> findAllByAuthorUsernameAndPublishDateBetween(String username, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+    Slice<SpotComment> findAllByAuthorUsernameAndPublishDateBetween(String username, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
 
-    Page<SpotComment> findAllByAuthorUsernameAndPublishDateGreaterThanEqual(String username, LocalDateTime startDate, Pageable pageable);
+    Slice<SpotComment> findAllByAuthorUsernameAndPublishDateGreaterThanEqual(String username, LocalDateTime startDate, Pageable pageable);
 
-    Page<SpotComment> findAllByAuthorUsernameAndPublishDateLessThanEqual(String username, LocalDateTime endDate, Pageable pageable);
+    Slice<SpotComment> findAllByAuthorUsernameAndPublishDateLessThanEqual(String username, LocalDateTime endDate, Pageable pageable);
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotCommentRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotCommentRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,7 +18,16 @@ public interface SpotCommentRepository extends JpaRepository<SpotComment, Long> 
 
     @EntityGraph(attributePaths = {"media", "upVotedBy", "downVotedBy"})
     Page<SpotComment> findBySpotIdOrderByPublishDateDescIdAsc(Long spotId, Pageable pageable);
+
     Optional<SpotComment> findCommentByIdAndAuthor(Long commentId, UserEntity author);
+
     List<SpotComment> findBySpotId(Long spotId);
-    List<SpotComment> findAllByAuthorUsername(String username);
+
+    Page<SpotComment> findAllByAuthorUsername(String username, Pageable pageable);
+
+    Page<SpotComment> findAllByAuthorUsernameAndPublishDateBetween(String username, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+    Page<SpotComment> findAllByAuthorUsernameAndPublishDateGreaterThanEqual(String username, LocalDateTime startDate, Pageable pageable);
+
+    Page<SpotComment> findAllByAuthorUsernameAndPublishDateLessThanEqual(String username, LocalDateTime endDate, Pageable pageable);
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotMediaRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotMediaRepository.java
@@ -3,15 +3,21 @@ package com.merkury.vulcanus.model.repositories;
 import com.merkury.vulcanus.model.entities.spot.SpotMedia;
 import com.merkury.vulcanus.model.entities.UserEntity;
 import com.merkury.vulcanus.model.enums.GenericMediaType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface SpotMediaRepository extends JpaRepository<SpotMedia, Long> {
-    List<SpotMedia> findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(String username, GenericMediaType genericMediaType, LocalDate startDate, LocalDate endDate);
-    List<SpotMedia>findByAuthorUsernameAndGenericMediaTypeAndAddDateGreaterThanEqual(String username, GenericMediaType genericMediaType, LocalDate startDate);
-    List<SpotMedia>findByAuthorUsernameAndGenericMediaTypeAndAddDateLessThanEqual(String username, GenericMediaType genericMediaType, LocalDate endDate);
-    List<SpotMedia> findAllByAuthorUsernameAndGenericMediaType(String username, GenericMediaType genericMediaType);
+    Page<SpotMedia> findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(String username, GenericMediaType genericMediaType, LocalDate startDate, LocalDate endDate, Pageable pageable);
+
+    Page<SpotMedia> findByAuthorUsernameAndGenericMediaTypeAndAddDateGreaterThanEqual(String username, GenericMediaType genericMediaType, LocalDate startDate, Pageable pageable);
+
+    Page<SpotMedia> findByAuthorUsernameAndGenericMediaTypeAndAddDateLessThanEqual(String username, GenericMediaType genericMediaType, LocalDate endDate, Pageable pageable);
+
+    Page<SpotMedia> findAllByAuthorUsernameAndGenericMediaType(String username, GenericMediaType genericMediaType, Pageable pageable);
+
     List<SpotMedia> findTop4ByAuthorAndGenericMediaTypeOrderByLikesDesc(UserEntity author, GenericMediaType genericMediaType);
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotMediaRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/SpotMediaRepository.java
@@ -3,21 +3,19 @@ package com.merkury.vulcanus.model.repositories;
 import com.merkury.vulcanus.model.entities.spot.SpotMedia;
 import com.merkury.vulcanus.model.entities.UserEntity;
 import com.merkury.vulcanus.model.enums.GenericMediaType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface SpotMediaRepository extends JpaRepository<SpotMedia, Long> {
-    Page<SpotMedia> findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(String username, GenericMediaType genericMediaType, LocalDate startDate, LocalDate endDate, Pageable pageable);
+    List<SpotMedia> findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(String username, GenericMediaType genericMediaType, LocalDate startDate, LocalDate endDate);
 
-    Page<SpotMedia> findByAuthorUsernameAndGenericMediaTypeAndAddDateGreaterThanEqual(String username, GenericMediaType genericMediaType, LocalDate startDate, Pageable pageable);
+    List<SpotMedia> findByAuthorUsernameAndGenericMediaTypeAndAddDateGreaterThanEqual(String username, GenericMediaType genericMediaType, LocalDate startDate);
 
-    Page<SpotMedia> findByAuthorUsernameAndGenericMediaTypeAndAddDateLessThanEqual(String username, GenericMediaType genericMediaType, LocalDate endDate, Pageable pageable);
+    List<SpotMedia> findByAuthorUsernameAndGenericMediaTypeAndAddDateLessThanEqual(String username, GenericMediaType genericMediaType, LocalDate endDate);
 
-    Page<SpotMedia> findAllByAuthorUsernameAndGenericMediaType(String username, GenericMediaType genericMediaType, Pageable pageable);
+    List<SpotMedia> findAllByAuthorUsernameAndGenericMediaType(String username, GenericMediaType genericMediaType);
 
     List<SpotMedia> findTop4ByAuthorAndGenericMediaTypeOrderByLikesDesc(UserEntity author, GenericMediaType genericMediaType);
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/UserEntityRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/UserEntityRepository.java
@@ -1,6 +1,8 @@
 package com.merkury.vulcanus.model.repositories;
 
 import com.merkury.vulcanus.model.entities.UserEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,11 +13,22 @@ import java.util.Optional;
 public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByEmail(String email);
+
     Optional<UserEntity> findByUsername(String username);
+
     Optional<UserEntity> findByEmail(String email);
+
     boolean existsByEmailAndIdNot(String email, Long id);
+
     boolean existsByUsernameAndIdNot(String username, Long id);
+
     Optional<UserEntity> findByUsernameOrEmail(String username, String email);
+
     List<UserEntity> findAllByEmail(String email);
+
     List<UserEntity> findAllByUsername(String username);
+
+    Page<UserEntity> findFollowersByFollowedUsername(String username, Pageable pageable);
+
+    Page<UserEntity> findFollowedByFollowersUsername(String username, Pageable pageable);
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/UserEntityRepository.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/repositories/UserEntityRepository.java
@@ -1,8 +1,8 @@
 package com.merkury.vulcanus.model.repositories;
 
 import com.merkury.vulcanus.model.entities.UserEntity;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,17 +18,13 @@ public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByEmail(String email);
 
-    boolean existsByEmailAndIdNot(String email, Long id);
-
-    boolean existsByUsernameAndIdNot(String username, Long id);
-
     Optional<UserEntity> findByUsernameOrEmail(String username, String email);
 
     List<UserEntity> findAllByEmail(String email);
 
     List<UserEntity> findAllByUsername(String username);
 
-    Page<UserEntity> findFollowersByFollowedUsername(String username, Pageable pageable);
+    Slice<UserEntity> findFollowersByFollowedUsername(String username, Pageable pageable);
 
-    Page<UserEntity> findFollowedByFollowersUsername(String username, Pageable pageable);
+    Slice<UserEntity> findFollowedByFollowersUsername(String username, Pageable pageable);
 }

--- a/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotServiceTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FavoriteSpotServiceTest.java
@@ -1,9 +1,9 @@
 package com.merkury.vulcanus.features.account.user.dashboard;
 
 import com.merkury.vulcanus.exception.exceptions.FavoriteSpotNotExistException;
+import com.merkury.vulcanus.model.entities.UserEntity;
 import com.merkury.vulcanus.model.entities.spot.FavoriteSpot;
 import com.merkury.vulcanus.model.entities.spot.Spot;
-import com.merkury.vulcanus.model.entities.UserEntity;
 import com.merkury.vulcanus.model.enums.user.dashboard.FavoriteSpotsListType;
 import com.merkury.vulcanus.model.repositories.FavoriteSpotRepository;
 import org.junit.jupiter.api.Test;
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
@@ -38,10 +40,11 @@ class FavoriteSpotServiceTest {
         var favoriteSpot2 = FavoriteSpot.builder().user(user).spot(spot2).type(FavoriteSpotsListType.FAVORITE).build();
 
         var favoriteSpotList = List.of(favoriteSpot, favoriteSpot2);
+        Page<FavoriteSpot> page = new PageImpl<>(favoriteSpotList);
 
-        when(favoriteSpotRepository.findAllByUserUsername(user.getUsername())).thenReturn(Optional.of(favoriteSpotList));
+        when(favoriteSpotRepository.findAllByUserUsername(user.getUsername(), PageRequest.of(0, 10))).thenReturn(page);
 
-        var result = favoriteSpotService.getUserFavoritesSpots(user.getUsername(), FavoriteSpotsListType.ALL);
+        var result = favoriteSpotService.getUserFavoritesSpots(user.getUsername(), FavoriteSpotsListType.ALL, 0, 10).items();
 
         assertAll(() -> assertEquals(2, result.size()),
                 () -> assertFalse(result.isEmpty()),
@@ -55,14 +58,13 @@ class FavoriteSpotServiceTest {
         var spot1 = Spot.builder().name("testSpot1").build();
 
         var favoriteSpot = FavoriteSpot.builder().user(user).spot(spot1).type(FavoriteSpotsListType.PLAN_TO_VISIT).build();
-
-        var favoriteSpotList = List.of(favoriteSpot);
+        Page<FavoriteSpot> page = new PageImpl<>(List.of(favoriteSpot));
 
         when(favoriteSpotRepository
-                .findAllByUserUsernameAndType(user.getUsername(), FavoriteSpotsListType.PLAN_TO_VISIT))
-                .thenReturn(Optional.of(favoriteSpotList));
+                .findAllByUserUsernameAndType(user.getUsername(), FavoriteSpotsListType.PLAN_TO_VISIT, PageRequest.of(0, 10)))
+                .thenReturn(page);
 
-        var result = favoriteSpotService.getUserFavoritesSpots(user.getUsername(), FavoriteSpotsListType.PLAN_TO_VISIT);
+        var result = favoriteSpotService.getUserFavoritesSpots(user.getUsername(), FavoriteSpotsListType.PLAN_TO_VISIT, 0, 10).items();
 
         assertAll(() -> assertEquals(1, result.size()),
                 () -> assertFalse(result.isEmpty()),

--- a/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FollowersServiceTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FollowersServiceTest.java
@@ -42,7 +42,7 @@ class FollowersServiceTest {
 
         when(userEntityFetcher.getByUsername("user1")).thenReturn(user);
 
-        var result = followersService.getUserFollowers("user1");
+        var result = followersService.getUserFollowers("user1", 0, 10);
 
         assertAll(() -> assertNotNull(result),
                 () -> assertTrue(result.stream().anyMatch(f -> f.username().equals("user2"))),
@@ -60,7 +60,7 @@ class FollowersServiceTest {
 
         when(userEntityFetcher.getByUsername("user1")).thenReturn(user);
 
-        var result = followersService.getUserFollowed("user1");
+        var result = followersService.getUserFollowed("user1", 0, 10);
 
         assertAll(() -> assertNotNull(result),
                 () -> assertTrue(result.stream().anyMatch(f -> f.username().equals("user2"))),
@@ -70,7 +70,7 @@ class FollowersServiceTest {
     @Test
     void shouldThrowUserNotFoundByUsernameExceptionWhenUserNotFound() throws UserNotFoundByUsernameException {
         when(userEntityFetcher.getByUsername(anyString())).thenThrow(new UserNotFoundByUsernameException(""));
-        assertThrows(UserNotFoundByUsernameException.class, () -> followersService.getUserFollowers(anyString()));
+        assertThrows(UserNotFoundByUsernameException.class, () -> followersService.getUserFollowers(anyString(), 0, 10));
     }
 
     @Test

--- a/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FriendsServiceTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FriendsServiceTest.java
@@ -45,7 +45,7 @@ class FriendsServiceTest {
 
         when(userEntityFetcher.getByUsername("user1")).thenReturn(user);
 
-        var result = friendsService.getUserFriends("user1", 0, 10);
+        var result = friendsService.getUserFriends("user1", 0, 10).items();
 
         assertAll(() -> assertNotNull(result),
                 () -> assertTrue(result.stream().anyMatch(f -> f.username().equals("user2"))),

--- a/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FriendsServiceTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/FriendsServiceTest.java
@@ -45,7 +45,7 @@ class FriendsServiceTest {
 
         when(userEntityFetcher.getByUsername("user1")).thenReturn(user);
 
-        var result = friendsService.getUserFriends("user1");
+        var result = friendsService.getUserFriends("user1", 0, 10);
 
         assertAll(() -> assertNotNull(result),
                 () -> assertTrue(result.stream().anyMatch(f -> f.username().equals("user2"))),
@@ -55,7 +55,7 @@ class FriendsServiceTest {
     @Test
     void shouldThrowUserNotFoundByUsernameExceptionWhenUserNotFound() throws UserNotFoundByUsernameException {
         when(userEntityFetcher.getByUsername(anyString())).thenThrow(new UserNotFoundByUsernameException(""));
-        assertThrows(UserNotFoundByUsernameException.class, () -> friendsService.getUserFriends(anyString()));
+        assertThrows(UserNotFoundByUsernameException.class, () -> friendsService.getUserFriends(anyString(), 0, 10));
     }
 
     @Test

--- a/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/MediaServiceTest.java
+++ b/vulcanus/src/test/java/com/merkury/vulcanus/features/account/user/dashboard/MediaServiceTest.java
@@ -11,18 +11,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static com.merkury.vulcanus.model.enums.user.dashboard.DateSortType.DATE_ASCENDING;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 
@@ -41,9 +35,7 @@ class MediaServiceTest {
         var photo2 = SpotMedia.builder().author(user).addDate(LocalDate.now()).likes(10).views(12).genericMediaType(GenericMediaType.PHOTO).build();
         var photosList = List.of(photo1, photo2);
 
-        Page<SpotMedia> page = new PageImpl<>(photosList);
-
-        when(spotMediaRepository.findAllByAuthorUsernameAndGenericMediaType(eq("user1"), eq(GenericMediaType.PHOTO), any(PageRequest.class))).thenReturn(page);
+        when(spotMediaRepository.findAllByAuthorUsernameAndGenericMediaType("user1", GenericMediaType.PHOTO)).thenReturn(photosList);
 
         var result = mediaService.getSortedUserPhotos("user1", DATE_ASCENDING, null, null, 0, 10).items();
 
@@ -67,14 +59,12 @@ class MediaServiceTest {
         var user = UserEntity.builder().username("user1").build();
         var photo = SpotMedia.builder().author(user).addDate(LocalDate.of(2025, 6, 15)).likes(12).views(15).genericMediaType(GenericMediaType.PHOTO).build();
 
-        Page<SpotMedia> page = new PageImpl<>(List.of(photo));
 
         when(spotMediaRepository.findAllByAuthorUsernameAndGenericMediaTypeAndAddDateBetween(
                 "user1",
                 GenericMediaType.PHOTO,
                 LocalDate.of(2025, 6, 15),
-                LocalDate.of(2025, 6, 16),
-                PageRequest.of(0, 10, Sort.by("addDate").ascending()))).thenReturn(page);
+                LocalDate.of(2025, 6, 16))).thenReturn(List.of(photo));
 
         var result = mediaService
                 .getSortedUserPhotos("user1", DATE_ASCENDING,


### PR DESCRIPTION
This pull request introduces pagination support to several user dashboard API endpoints and updates related frontend components to use infinite scrolling. The main changes include refactoring backend data fetch methods to accept pagination parameters, updating their return types to paged DTOs, and modifying the UI to load additional data as the user scrolls. This improves performance and user experience, especially for large data sets.

### Backend API and DTO changes

**Pagination support added to API methods:**
* Refactored functions in `venus/src/http/user-dashboard.ts` to accept `page` and `size` parameters for fetching friends, followers, followed users, favorite spots, user photos, movies, and comments. Return types updated to paged DTOs (e.g., `SocialPageDto`, `FavoriteSpotPageDto`, `DatedMediaGroupPageDto`, `DatedCommentsGroupPageDto`). [[1]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL36-R65) [[2]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL63-R154) [[3]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL119-R207) [[4]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL171-R245) [[5]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL207-R274)
* Removed obsolete API methods and unused imports in `venus/src/http/spots-data.ts` and `venus/src/http/user-dashboard.ts`. [[1]](diffhunk://#diff-7c93ce0156a6b89372a1e6f9dd1c41c50ad2e867833c980e21779f8004e25762L78-L86) [[2]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL3-R12)

**New paged DTOs:**
* Added DTO interfaces for paginated results: `SocialPageDto`, `FavoriteSpotPageDto`, `DatedMediaGroupPageDto`, and `DatedCommentsGroupPageDto`. Each includes an `items` array and a `hasNext` boolean. [[1]](diffhunk://#diff-ca05d906398fcd662dec47012a8404b38facf317d6033f7b9e6a26fb595b4f59R1-R6) [[2]](diffhunk://#diff-12119ac8ac3d7eb64f4e3af23b4a4acac9b05c03ea8aec052783b8c17a2b8d87R1-R6) [[3]](diffhunk://#diff-2f18aee6b824e99c48999852fc78bc8c46915338fd5818c2a532cd260c290a77R1-R6) [[4]](diffhunk://#diff-8fcadbe2d7e50f2df1ee6a1892ea50e353e1d3ab77597447beaa1e4acd7a9d91R1-R6)

### Frontend infinite scrolling

**UI components updated for infinite loading:**
* Refactored `Comments.tsx` and `FavoriteSpots.tsx` to use `useInfiniteQuery` from React Query, loading more items as the user scrolls using an Intersection Observer on a sentinel element. Data is now flattened from paged responses. [[1]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL11-R64) [[2]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL54-R90) [[3]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL73-R114) [[4]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8L2-R7) [[5]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8R26-R63) [[6]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8L57-R99)
* Updated UI logic to display loading spinners during data fetches and to show empty-state messages only when no items are present. [[1]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL54-R90) [[2]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8L57-R99)

**Media component props updated:**
* Modified `Media.tsx` to accept `loadMoreRef` and `isFetchingNextPage` props for infinite scrolling and loading indicators. [[1]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R12) [[2]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R21-R22) [[3]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R32-R33) [[4]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R80-R81)

---

**Change references:**  
[[1]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL36-R65) [[2]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL63-R154) [[3]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL119-R207) [[4]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL171-R245) [[5]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL207-R274) [[6]](diffhunk://#diff-7c93ce0156a6b89372a1e6f9dd1c41c50ad2e867833c980e21779f8004e25762L78-L86) [[7]](diffhunk://#diff-647739b90a3071bbf881c883ed3caedb10189183258fcf5eec17d9b2dd5d5e3dL3-R12) [[8]](diffhunk://#diff-ca05d906398fcd662dec47012a8404b38facf317d6033f7b9e6a26fb595b4f59R1-R6) [[9]](diffhunk://#diff-12119ac8ac3d7eb64f4e3af23b4a4acac9b05c03ea8aec052783b8c17a2b8d87R1-R6) [[10]](diffhunk://#diff-2f18aee6b824e99c48999852fc78bc8c46915338fd5818c2a532cd260c290a77R1-R6) [[11]](diffhunk://#diff-8fcadbe2d7e50f2df1ee6a1892ea50e353e1d3ab77597447beaa1e4acd7a9d91R1-R6) [[12]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL11-R64) [[13]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL54-R90) [[14]](diffhunk://#diff-295601b42711dbcb770f3fe69edefe24e8320c8a19e1f772410e3828cd8e6f8eL73-R114) [[15]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8L2-R7) [[16]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8R26-R63) [[17]](diffhunk://#diff-b586a6182ba0e0474b16ab44a65034586e66827a5aad7088b42249979279fba8L57-R99) [[18]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R12) [[19]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R21-R22) [[20]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R32-R33) [[21]](diffhunk://#diff-7c950e459d6777ae5b90f6115101c41e0e943708c68ae1c18d9d068b9a7bc394R80-R81)