### PR TITLE
fix/MER-255

### DIFF
--- a/venus/src/layout/sidebar/components/sidebar-item/SidebarItem.tsx
+++ b/venus/src/layout/sidebar/components/sidebar-item/SidebarItem.tsx
@@ -8,6 +8,8 @@ import SidebarItemSubmenu from "./SidebarItemSubmenu";
 import SidebarItemAction from "./SidebarItemAction";
 import SidebarItemLink from "./SidebarItemLink";
 import { useBoolean } from "../../../../hooks/useBoolean";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 
 interface SidebarItemProps {
     link: BaseLink;
@@ -23,6 +25,11 @@ export default function SidebarItem({
     index,
 }: SidebarItemProps) {
     const [isTooltipShown, showTooltip, hideTooltip] = useBoolean(false);
+    const location = useLocation();
+
+    useEffect(() => {
+        hideTooltip();
+    }, [location.pathname]);
 
     switch (link.type) {
         case "submenu":


### PR DESCRIPTION
This pull request introduces a small but important improvement to the sidebar component's behavior. The change ensures that the tooltip for a sidebar item is hidden whenever the route changes, providing a smoother user experience when navigating between pages.

Enhancement to sidebar tooltip behavior:

* Added a `useEffect` in `SidebarItem.tsx` to automatically hide the tooltip when the route (`location.pathname`) changes, using React Router's `useLocation` hook. [[1]](diffhunk://#diff-051ef3e29be961c172d18af37a21405bfcba557bb8b2026f51e8daaad894f925R11-R12) [[2]](diffhunk://#diff-051ef3e29be961c172d18af37a21405bfcba557bb8b2026f51e8daaad894f925R28-R32)