### PR TITLE
refactor/MER-290

### DIFF
--- a/venus/src/http/spots-data.ts
+++ b/venus/src/http/spots-data.ts
@@ -4,8 +4,8 @@ import SpotDetails from "../model/interface/spot/spotDetails";
 import GeneralSpot from "../model/interface/spot/generalSpot";
 import SearchSpotDtoPage from "../model/interface/spot/search-spot/searchSpotDtoPage";
 import { TopRatedSpot } from "../model/interface/spot/topRatedSpot";
-import HomePageSpotDto from "../model/interface/spot/search-spot/homePageSpotDto";
 import { SpotSearchRequestDto } from "../model/interface/spot/spotSearchRequestDto";
+import { HomePageSpotPageDto } from "../model/interface/spot/search-spot/homePageSpotPageDto";
 const BASE_URL = import.meta.env.VITE_MERKURY_BASE_URL;
 
 export async function fetchFilteredSpots(name: string): Promise<GeneralSpot[]> {
@@ -117,7 +117,9 @@ interface SearchLocation {
 
 export async function getSearchedSpotsOnHomePage(
     searchLocation: SearchLocation,
-): Promise<HomePageSpotDto[]> {
+    page: number,
+    size: number,
+): Promise<HomePageSpotPageDto> {
     return (
         await axios.get(`${BASE_URL}/public/spot/search/home-page`, {
             params: {
@@ -126,6 +128,8 @@ export async function getSearchedSpotsOnHomePage(
                 city: searchLocation.city,
                 userLongitude: searchLocation.userLongitude,
                 userLatitude: searchLocation.userLatitude,
+                page,
+                size,
             },
         })
     ).data;
@@ -147,10 +151,12 @@ export async function getLocations(
 
 export async function getSearchedSpotsOnAdvanceHomePage(
     spotSearchRequestDto: SpotSearchRequestDto,
-): Promise<HomePageSpotDto[]> {
+    page: number,
+    size: number,
+): Promise<HomePageSpotPageDto> {
     return (
         await axios.get(`${BASE_URL}/public/spot/search/home-page/advance`, {
-            params: spotSearchRequestDto,
+            params: { spotSearchRequestDto, page, size },
             paramsSerializer: (params) => queryString.stringify(params),
         })
     ).data;

--- a/venus/src/http/spots-data.ts
+++ b/venus/src/http/spots-data.ts
@@ -156,7 +156,7 @@ export async function getSearchedSpotsOnAdvanceHomePage(
 ): Promise<HomePageSpotPageDto> {
     return (
         await axios.get(`${BASE_URL}/public/spot/search/home-page/advance`, {
-            params: { spotSearchRequestDto, page, size },
+            params: { ...spotSearchRequestDto, page, size },
             paramsSerializer: (params) => queryString.stringify(params),
         })
     ).data;

--- a/venus/src/model/interface/spot/search-spot/homePageSpotPageDto.ts
+++ b/venus/src/model/interface/spot/search-spot/homePageSpotPageDto.ts
@@ -1,0 +1,6 @@
+import HomePageSpotDto from "./homePageSpotDto";
+
+export interface HomePageSpotPageDto {
+    items: HomePageSpotDto[];
+    hasNext: boolean;
+}

--- a/venus/src/pages/home-page/AdvanceHomePage.tsx
+++ b/venus/src/pages/home-page/AdvanceHomePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import SearchSpotList from "./components/SearchSpotList";
 import Switch from "./components/Switch";
 import AdvanceSearchBar from "./components/AdvanceSearchBar";
@@ -6,6 +6,9 @@ import HomePageSpotDto from "../../model/interface/spot/search-spot/homePageSpot
 
 export default function AdvanceHomePage() {
     const [searchedSpots, setSearchedSpots] = useState<HomePageSpotDto[]>([]);
+    const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
     const handleSetSearchedSpots = (spots: HomePageSpotDto[]) => {
         setSearchedSpots(spots);
@@ -14,9 +17,17 @@ export default function AdvanceHomePage() {
     return (
         <div className="dark:bg-darkBg dark:text-darkText bg-lightBg text-lightText mt-10 flex min-h-screen w-full flex-col items-center space-y-4 overflow-hidden p-8">
             <Switch />
-            <AdvanceSearchBar onSetSpots={handleSetSearchedSpots} />
+            <AdvanceSearchBar
+                onSetSpots={handleSetSearchedSpots}
+                loadMoreRef={loadMoreRef}
+                onSetFetchingNextPage={setIsFetchingNextPage}
+            />
             <div className="flex w-full flex-col items-center space-y-10">
-                <SearchSpotList spots={searchedSpots} />
+                <SearchSpotList
+                    spots={searchedSpots}
+                    loadMoreRef={loadMoreRef}
+                    isFetchingNextPage={isFetchingNextPage}
+                />
             </div>
         </div>
     );

--- a/venus/src/pages/home-page/HomePage.tsx
+++ b/venus/src/pages/home-page/HomePage.tsx
@@ -3,7 +3,7 @@ import { get18MostPopularSpots } from "../../http/spots-data";
 import Carousel from "./components/Carousel";
 import LoadingSpinner from "../../components/loading-spinner/LoadingSpinner";
 import SearchBar from "./components/SearchBar";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import SearchSpotList from "./components/SearchSpotList";
 import Switch from "./components/Switch";
 import HomePageSpotDto from "../../model/interface/spot/search-spot/homePageSpotDto";
@@ -16,6 +16,9 @@ export default function HomePage() {
 
     const [searchedSpots, setSearchedSpots] = useState<HomePageSpotDto[]>([]);
     const [spotsPerPage, setSpotsPerPage] = useState(6);
+    const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+
+    const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
     useEffect(() => {
         const handleResize = () => {
@@ -47,12 +50,20 @@ export default function HomePage() {
     return (
         <div className="dark:bg-darkBg dark:text-darkText bg-lightBg text-lightText mt-10 flex min-h-screen w-full flex-col items-center space-y-4 overflow-hidden p-8">
             <Switch />
-            <SearchBar onSetSpots={handleSetSearchedSpots} />
+            <SearchBar
+                onSetSpots={handleSetSearchedSpots}
+                loadMoreRef={loadMoreRef}
+                onSetFetchingNextPage={setIsFetchingNextPage}
+            />
             <div className="flex w-full flex-col items-center space-y-4">
                 <h1 className="text-center text-3xl">The Most Popular Spots</h1>
                 <div className="flex w-full flex-col items-center space-y-10">
                     <Carousel spots={data!} spotsPerPage={spotsPerPage} />
-                    <SearchSpotList spots={searchedSpots} />
+                    <SearchSpotList
+                        spots={searchedSpots}
+                        isFetchingNextPage={isFetchingNextPage}
+                        loadMoreRef={loadMoreRef}
+                    />
                 </div>
             </div>
         </div>

--- a/venus/src/pages/home-page/components/AdvanceSearchBar.tsx
+++ b/venus/src/pages/home-page/components/AdvanceSearchBar.tsx
@@ -122,9 +122,12 @@ export default function AdvanceSearchBar({
         );
 
         observer.observe(loadMoreRef.current);
-        onSetFetchingNextPage(isFetchingNextPage);
         return () => observer.disconnect();
     }, [hasNextPage, isFetchingNextPage, fetchNextPage, onSetSpots]);
+
+    useEffect(() => {
+        onSetFetchingNextPage(isFetchingNextPage);
+    }, [isFetchingNextPage, onSetFetchingNextPage]);
 
     return (
         <div className="dark:bg-darkBgSoft bg-lightBgSoft flex w-full flex-col items-center justify-between space-y-3 rounded-md px-3 py-2 shadow-md md:flex-row md:space-y-0 lg:w-3/4 lg:space-x-3 xl:w-1/2 dark:shadow-black">

--- a/venus/src/pages/home-page/components/AdvanceSearchBar.tsx
+++ b/venus/src/pages/home-page/components/AdvanceSearchBar.tsx
@@ -1,7 +1,7 @@
 import SearchInput from "./SearchInput";
 import { FaPlus, FaSearch } from "react-icons/fa";
-import { useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { MutableRefObject, useEffect, useState } from "react";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
     getLocations,
     getSearchedSpotsOnAdvanceHomePage,
@@ -21,16 +21,29 @@ const initialValue = {
 
 interface SearchBarProps {
     onSetSpots: (spots: HomePageSpotDto[]) => void;
+    onSetFetchingNextPage: (fetching: boolean) => void;
+    loadMoreRef: MutableRefObject<HTMLDivElement | null>;
 }
 
-export default function AdvanceSearchBar({ onSetSpots }: SearchBarProps) {
+export default function AdvanceSearchBar({
+    onSetSpots,
+    loadMoreRef,
+    onSetFetchingNextPage,
+}: SearchBarProps) {
     const [searchLocation, setSearchLocation] =
         useState<SearchLocation>(initialValue);
     const [activeInput, setActiveInput] = useState<"city" | "tags" | null>();
 
-    const { mutateAsync } = useMutation({
-        mutationFn: getSearchedSpotsOnAdvanceHomePage,
-    });
+    const { fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
+        useInfiniteQuery({
+            queryKey: ["homePageSpots", searchLocation],
+            queryFn: ({ pageParam = 0 }) =>
+                getSearchedSpotsOnAdvanceHomePage(searchLocation, pageParam, 5),
+            getNextPageParam: (lastPage, allPages) =>
+                lastPage.hasNext ? allPages.length : undefined,
+            initialPageParam: 0,
+            enabled: false,
+        });
 
     const { data: suggestions = [] } = useQuery({
         queryKey: [
@@ -83,10 +96,35 @@ export default function AdvanceSearchBar({ onSetSpots }: SearchBarProps) {
     };
 
     const handleSearchSpots = async () => {
-        const spots = await mutateAsync(searchLocation);
-        onSetSpots(spots);
+        const result = await refetch();
+        onSetSpots(result.data?.pages[0]?.items ?? []);
         setActiveInput(null);
     };
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (
+                    entries[0].isIntersecting &&
+                    hasNextPage &&
+                    !isFetchingNextPage
+                ) {
+                    fetchNextPage().then((res) => {
+                        onSetSpots(
+                            res.data?.pages.flatMap((p) => p.items) ?? [],
+                        );
+                    });
+                }
+            },
+            { threshold: 1.0 },
+        );
+
+        observer.observe(loadMoreRef.current);
+        onSetFetchingNextPage(isFetchingNextPage);
+        return () => observer.disconnect();
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage, onSetSpots]);
 
     return (
         <div className="dark:bg-darkBgSoft bg-lightBgSoft flex w-full flex-col items-center justify-between space-y-3 rounded-md px-3 py-2 shadow-md md:flex-row md:space-y-0 lg:w-3/4 lg:space-x-3 xl:w-1/2 dark:shadow-black">

--- a/venus/src/pages/home-page/components/SearchBar.tsx
+++ b/venus/src/pages/home-page/components/SearchBar.tsx
@@ -157,9 +157,12 @@ export default function SearchBar({
         );
 
         observer.observe(loadMoreRef.current);
-        onSetFetchingNextPage(isFetchingNextPage);
         return () => observer.disconnect();
     }, [hasNextPage, isFetchingNextPage, fetchNextPage, onSetSpots]);
+
+    useEffect(() => {
+        onSetFetchingNextPage(isFetchingNextPage);
+    }, [isFetchingNextPage, onSetFetchingNextPage]);
 
     return (
         <div className="dark:bg-darkBgSoft bg-lightBgSoft flex w-full flex-col items-center justify-between space-y-3 rounded-md px-3 py-2 shadow-md md:flex-row md:space-y-0 lg:w-3/4 lg:space-x-3 xl:w-1/2 dark:shadow-black">

--- a/venus/src/pages/home-page/components/SearchBar.tsx
+++ b/venus/src/pages/home-page/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import SearchInput from "./SearchInput";
 import { FaSearch } from "react-icons/fa";
-import { useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { MutableRefObject, useEffect, useState } from "react";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
     getLocations,
     getSearchedSpotsOnHomePage,
@@ -43,18 +43,39 @@ const initialValue = {
 
 interface SearchBarProps {
     onSetSpots: (spots: HomePageSpotDto[]) => void;
+    onSetFetchingNextPage: (fetching: boolean) => void;
+    loadMoreRef: MutableRefObject<HTMLDivElement | null>;
 }
 
-export default function SearchBar({ onSetSpots }: SearchBarProps) {
+export default function SearchBar({
+    onSetSpots,
+    loadMoreRef,
+    onSetFetchingNextPage,
+}: SearchBarProps) {
     const dispatch = useDispatchTyped();
 
+    const [userCoords, setUserCoords] = useState<{
+        latitude?: number;
+        longitude?: number;
+    }>({});
     const [searchLocation, setSearchLocation] =
         useState<SearchLocation>(initialValue);
     const [activeInput, setActiveInput] = useState<LocationKey | null>(null);
 
-    const { mutateAsync } = useMutation({
-        mutationFn: getSearchedSpotsOnHomePage,
-    });
+    const { fetchNextPage, hasNextPage, isFetchingNextPage, refetch } =
+        useInfiniteQuery({
+            queryKey: ["homePageSpots"],
+            queryFn: ({ pageParam = 0 }) =>
+                getSearchedSpotsOnHomePage(
+                    { ...searchLocation, ...userCoords },
+                    pageParam,
+                    5,
+                ),
+            getNextPageParam: (lastPage, allPages) =>
+                lastPage.hasNext ? allPages.length : undefined,
+            initialPageParam: 0,
+            enabled: false,
+        });
 
     const { data: suggestions = [] } = useQuery({
         queryKey: [
@@ -98,10 +119,9 @@ export default function SearchBar({ onSetSpots }: SearchBarProps) {
     };
 
     const handleSearchSpots = async () => {
-        let coords;
-
         try {
-            coords = await getUserLocation();
+            const coords = await getUserLocation();
+            setUserCoords(coords);
         } catch (err) {
             dispatch(
                 notificationAction.addInfo({
@@ -111,14 +131,35 @@ export default function SearchBar({ onSetSpots }: SearchBarProps) {
             );
         }
 
-        const spots = await mutateAsync({
-            ...searchLocation,
-            userLongitude: coords?.longitude,
-            userLatitude: coords?.latitude,
-        });
-        onSetSpots(spots);
+        const result = await refetch();
+        onSetSpots(result.data?.pages[0]?.items ?? []);
         setActiveInput(null);
     };
+
+    useEffect(() => {
+        if (!loadMoreRef.current) return;
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (
+                    entries[0].isIntersecting &&
+                    hasNextPage &&
+                    !isFetchingNextPage
+                ) {
+                    fetchNextPage().then((res) => {
+                        onSetSpots(
+                            res.data?.pages.flatMap((p) => p.items) ?? [],
+                        );
+                    });
+                }
+            },
+            { threshold: 1.0 },
+        );
+
+        observer.observe(loadMoreRef.current);
+        onSetFetchingNextPage(isFetchingNextPage);
+        return () => observer.disconnect();
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage, onSetSpots]);
 
     return (
         <div className="dark:bg-darkBgSoft bg-lightBgSoft flex w-full flex-col items-center justify-between space-y-3 rounded-md px-3 py-2 shadow-md md:flex-row md:space-y-0 lg:w-3/4 lg:space-x-3 xl:w-1/2 dark:shadow-black">

--- a/venus/src/pages/home-page/components/SearchSpotList.tsx
+++ b/venus/src/pages/home-page/components/SearchSpotList.tsx
@@ -1,11 +1,19 @@
 import SpotTile from "./SpotTile";
 import HomePageSpotDto from "../../../model/interface/spot/search-spot/homePageSpotDto";
+import LoadingSpinner from "../../../components/loading-spinner/LoadingSpinner";
+import { MutableRefObject } from "react";
 
 interface SearchSpotListProps {
     spots: HomePageSpotDto[];
+    isFetchingNextPage: boolean;
+    loadMoreRef: MutableRefObject<HTMLDivElement | null>;
 }
 
-export default function SearchSpotList({ spots }: SearchSpotListProps) {
+export default function SearchSpotList({
+    spots,
+    isFetchingNextPage,
+    loadMoreRef,
+}: SearchSpotListProps) {
     return (
         <>
             <ul className="grid w-full grid-cols-1 place-items-center gap-8 xl:grid-cols-2 2xl:grid-cols-3">
@@ -13,6 +21,8 @@ export default function SearchSpotList({ spots }: SearchSpotListProps) {
                     <SpotTile key={spot.id} spot={spot} />
                 ))}
             </ul>
+            <div ref={loadMoreRef} className="h-10" />
+            {isFetchingNextPage && <LoadingSpinner />}
             {spots.length === 0 && (
                 <p className="text-center text-2xl">
                     Search for spots to see results.

--- a/vulcanus/src/main/java/com/merkury/vulcanus/controllers/SpotController.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/controllers/SpotController.java
@@ -77,12 +77,14 @@ public class SpotController {
     }
 
     @GetMapping("/public/spot/search/home-page")
-    public ResponseEntity<List<HomePageSpotDto>> getSearchedSpotsOnHomePage(@RequestParam(required = false) String country,
+    public ResponseEntity<HomePageSpotPageDto> getSearchedSpotsOnHomePage(@RequestParam(required = false) String country,
                                                                             @RequestParam(required = false) String region,
                                                                             @RequestParam(required = false) String city,
                                                                             @RequestParam(required = false) Double userLongitude,
-                                                                            @RequestParam(required = false) Double userLatitude) {
-        return ResponseEntity.ok(spotService.getAllSpotsByLocation(country, region, city, userLongitude, userLatitude));
+                                                                            @RequestParam(required = false) Double userLatitude,
+                                                                            @RequestParam(defaultValue = "0") int page,
+                                                                            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(spotService.getAllSpotsByLocation(country, region, city, userLongitude, userLatitude, page, size));
     }
 
     @GetMapping("/public/spot/search/home-page/locations")
@@ -93,10 +95,12 @@ public class SpotController {
     }
 
     @GetMapping("/public/spot/search/home-page/advance")
-    public ResponseEntity<List<HomePageSpotDto>> getSearchedSpotsOnHomePage(@RequestParam(required = false) String city,
+    public ResponseEntity<HomePageSpotPageDto> getSearchedSpotsOnHomePage(@RequestParam(required = false) String city,
                                                                             @RequestParam(required = false) List<String> tags,
                                                                             @RequestParam(required = false) Double userLongitude,
-                                                                            @RequestParam(required = false) Double userLatitude) {
-        return ResponseEntity.ok(spotService.getAllSpotsByLocationAndTags(city, tags, userLongitude, userLatitude));
+                                                                            @RequestParam(required = false) Double userLatitude,
+                                                                            @RequestParam(defaultValue = "0") int page,
+                                                                            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(spotService.getAllSpotsByLocationAndTags(city, tags, userLongitude, userLatitude, page, size));
     }
 }

--- a/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/spot/HomePageSpotPageDto.java
+++ b/vulcanus/src/main/java/com/merkury/vulcanus/model/dtos/spot/HomePageSpotPageDto.java
@@ -1,0 +1,7 @@
+package com.merkury.vulcanus.model.dtos.spot;
+
+
+import java.util.List;
+
+public record HomePageSpotPageDto(List<HomePageSpotDto> items, boolean hasNext) {
+}


### PR DESCRIPTION
This pull request introduces cursor-based pagination for spot search endpoints on both the backend and frontend, improving scalability and user experience when browsing large spot lists. The changes update API endpoints and DTOs to support paginated responses, refactor frontend data fetching to use infinite queries, and add intersection observer logic for seamless "load more" functionality.

### Backend API and DTO changes

* Updated `getSearchedSpotsOnHomePage` and `getSearchedSpotsOnAdvanceHomePage` controller methods to return a paginated response (`HomePageSpotPageDto`) instead of a simple list, adding `page` and `size` parameters to support pagination. [[1]](diffhunk://#diff-14845272c802525e6586a4bb3584d121c71b110b3ca41d4e70c101ab53d9b352L80-R87) [[2]](diffhunk://#diff-14845272c802525e6586a4bb3584d121c71b110b3ca41d4e70c101ab53d9b352L96-R104)
* Added the new DTO `HomePageSpotPageDto` containing `items` and `hasNext` fields, representing the paginated spot list and whether more results are available.

### Frontend API integration

* Refactored `getSearchedSpotsOnHomePage` and `getSearchedSpotsOnAdvanceHomePage` functions to accept `page` and `size` arguments and return the new paginated DTO. [[1]](diffhunk://#diff-7c93ce0156a6b89372a1e6f9dd1c41c50ad2e867833c980e21779f8004e25762L120-R122) [[2]](diffhunk://#diff-7c93ce0156a6b89372a1e6f9dd1c41c50ad2e867833c980e21779f8004e25762L150-R159)
* Updated imports to use the new DTO and removed unused imports.

### Frontend data fetching and infinite scroll

* Replaced mutation-based fetching with `useInfiniteQuery` in both `SearchBar` and `AdvanceSearchBar`, enabling infinite loading of spot results as the user scrolls. [[1]](diffhunk://#diff-2c9f8c4f85cf9dde9cb455448fe064d8c8163b100bc07288bb9efc5ab202acbaL3-R4) [[2]](diffhunk://#diff-251cf252b646bf004c9440d6bf7ecd64fff7676a4aa731b27f57023139814ca1L3-R4)
* Implemented intersection observer logic to trigger fetching the next page when the user scrolls to the bottom of the list, and wired up loading spinner and "load more" UI feedback. [[1]](diffhunk://#diff-2c9f8c4f85cf9dde9cb455448fe064d8c8163b100bc07288bb9efc5ab202acbaL86-R128) [[2]](diffhunk://#diff-251cf252b646bf004c9440d6bf7ecd64fff7676a4aa731b27f57023139814ca1L114-R163) [[3]](diffhunk://#diff-baa5933eb563a0710b4c42f02641d238c321ba2fe0a9a0970a92ca3b57db93c3R3-R25)

### Component and prop updates

* Updated `HomePage`, `AdvanceHomePage`, and related components to pass the necessary props (`loadMoreRef`, `isFetchingNextPage`, etc.) for infinite loading, and refactored `SearchSpotList` to display the loading spinner and handle the new props. [[1]](diffhunk://#diff-80aebc32951b893756ea951b7bbb527422d0f1b839105507e0ff048e21c86832L17-R30) [[2]](diffhunk://#diff-a76cbb5258cee2edbcde53984896d2ef3233a8ea84598b3155ef7c763facb501L50-R66) [[3]](diffhunk://#diff-baa5933eb563a0710b4c42f02641d238c321ba2fe0a9a0970a92ca3b57db93c3R3-R25)

### Miscellaneous

* Minor code cleanups, such as import adjustments and state management improvements for user coordinates and loading state. [[1]](diffhunk://#diff-a76cbb5258cee2edbcde53984896d2ef3233a8ea84598b3155ef7c763facb501L6-R6) [[2]](diffhunk://#diff-251cf252b646bf004c9440d6bf7ecd64fff7676a4aa731b27f57023139814ca1L101-R124) [[3]](diffhunk://#diff-3628da5a85c6e35a461e160d3bdc48eddd4a5217529d784e50d628b290518370L19-R19)