### PR TITLE
fix/MER-294

### DIFF
--- a/venus/src/pages/account/add-spot/components/AddSpotModal.tsx
+++ b/venus/src/pages/account/add-spot/components/AddSpotModal.tsx
@@ -31,6 +31,18 @@ const addressInputConfig: ConfigTyp = [
     { name: "street", type: "text", id: "street" },
 ];
 
+const initialValue: SpotToAddDto = {
+    id: 0,
+    name: "",
+    description: "",
+    country: "",
+    region: "",
+    city: "",
+    street: "",
+    borderPoints: [],
+    media: [],
+};
+
 interface AddSpotModalProps {
     onClose: () => void;
     isOpen: boolean;
@@ -45,17 +57,7 @@ export default function AddSpotModal({ onClose, isOpen }: AddSpotModalProps) {
         borderPoints?: string | null;
     }>({});
 
-    const [spot, setSpot] = useState<SpotToAddDto>({
-        id: 0,
-        name: "",
-        description: "",
-        country: "",
-        region: "",
-        city: "",
-        street: "",
-        borderPoints: [],
-        media: [],
-    });
+    const [spot, setSpot] = useState<SpotToAddDto>(initialValue);
 
     const debouncedStreet = useDebounce(spot.street, 500);
     const debouncedCity = useDebounce(spot.city, 500);
@@ -84,6 +86,7 @@ export default function AddSpotModal({ onClose, isOpen }: AddSpotModalProps) {
                     message: "Successfully add spot.",
                 }),
             );
+            setSpot(initialValue);
             await queryClient.invalidateQueries({ queryKey: ["add-spot"] });
         },
         onError: () => {


### PR DESCRIPTION
This pull request refactors the initialization of the `spot` state in the `AddSpotModal` component to improve code maintainability and consistency. The main change is the introduction of a shared `initialValue` object for the spot's default state, which is now reused in both the state initialization and when resetting the form after a successful spot addition.

State management improvements:

* Introduced a single `initialValue` object of type `SpotToAddDto` to centralize the default values for a new spot, replacing the inline object previously used for initializing the `spot` state. (`venus/src/pages/account/add-spot/components/AddSpotModal.tsx`)
* Updated the `useState` hook for `spot` to use the new `initialValue` object, ensuring consistency and easier maintenance. (`venus/src/pages/account/add-spot/components/AddSpotModal.tsx`)
* After a successful spot addition, reset the `spot` state to `initialValue` to clear the form fields for the next entry. (`venus/src/pages/account/add-spot/components/AddSpotModal.tsx`)