### PR TITLE
Fix/MER-305

### DIFF
--- a/venus/src/pages/spot/components/comments/SpotCommentAuthor.tsx
+++ b/venus/src/pages/spot/components/comments/SpotCommentAuthor.tsx
@@ -10,7 +10,7 @@ export default function SpotCommentAuthor({ author }: SpotCommentAuthorProps) {
             <img
                 src={author.profilePhotoUrl}
                 alt={author.username}
-                className="h-10 rounded-full"
+                className="h-10 aspect-square rounded-full"
             />
             <p className="text-3xl">{author.username}</p>
         </div>


### PR DESCRIPTION
Naprawa błędu, że po zmianie zdjęcia profilowego użytkownika, w komentarzach spota nie wyświetlało się jako koło.