### PR TITLE
Add new bibliography entries

### DIFF
--- a/book/bibliography.bib
+++ b/book/bibliography.bib
@@ -197,4 +197,13 @@
     date = {2012-10-01}
 }
 
-%TODO: do porpawy tyutaj organizacje?
+@book{schwarzmuller-react-key-concepts-pl,
+    author = {Maximilian Schwarzmuller},
+    title = {React kluczowe koncepcje. Przewodnik po najważniejszych mechanizmach biblioteki React},
+    publisher = {Helion},
+    year = {2023},
+    location = {Gliwice},
+    isbn = {978-83-8322-885-3},
+    translator = {Tomasz Walczak},
+    note = {Tytuł oryginału: \emph{React Key Concepts: Consolidate your knowledge of React’s core features}. Packt Publishing, 2022}
+}

--- a/book/bibliography.bib
+++ b/book/bibliography.bib
@@ -207,3 +207,14 @@
     translator = {Tomasz Walczak},
     note = {Tytuł oryginału: \emph{React Key Concepts: Consolidate your knowledge of React’s core features}. Packt Publishing, 2022}
 }
+
+@book{flanagan-js-definitive-guide-pl,
+    author = {David Flanagan},
+    title = {JavaScript. Przewodnik. Poznaj język mistrzów programowania},
+    publisher = {Helion},
+    year = {2021},
+    location = {Gliwice},
+    isbn = {978-83-283-7309-9},
+    translator = {Andrzej Watrak},
+    note = {Tytuł oryginału: \emph{JavaScript: The Definitive Guide: Master the World's Most-Used Programming Language}, 7th Edition. O’Reilly Media, 2020 (ISBN 9781491952023)}
+}

--- a/book/bibliography.bib
+++ b/book/bibliography.bib
@@ -111,30 +111,7 @@
     urldate = {2025-11-02},
 }
 
-@book{uml-def,
-    author = {Stanisław Wrycza and Bartosz Marcinkowski and Krzysztof Wyrzykowski},
-    title = {Język UML 2.0 w modelowaniu systemów informatycznych},
-    publisher = {Helion},
-    isbn = {83-736-1892-9, 8373618929},
-    year = {2006},
-    location = {Warszawa}
-}
 
-@book{wzorce-projektowe,
-    author = {Aleksander Shvets},
-    title = {Wzorce Projektowe Nowoczesny Podręcznik},
-    publisher = {Refactoring Guru},
-    year ={2022},
-    location = {Pamplona}
-}
-
-@online{bpmn-def,
-    title = {10 wskazówek poprawiających modelowanie procesów biznesowych w notacji BPMN},
-    author = {Michał Wolski},
-    url = {https://wolski.pro/2024/05/10-wskazowek-poprawiajacych-modelowanie-procesow-biznesowych-w-notacji-bpmn/},
-    urldate = {2025-11-19},
-    date = {2024-05-14},
-}
 
 @online{dronemap,
     title = {DroneMap PANSA},
@@ -217,4 +194,32 @@
     isbn = {978-83-283-7309-9},
     translator = {Andrzej Watrak},
     note = {Tytuł oryginału: \emph{JavaScript: The Definitive Guide: Master the World's Most-Used Programming Language}, 7th Edition. O’Reilly Media, 2020 (ISBN 9781491952023)}
+}
+
+@book{drejewicz-bpmn,
+    author = {Szymon Drejewicz},
+    title = {Zrozumieć BPMN. Modelowanie procesów biznesowych},
+    publisher = {onepress},
+    year = {2023},
+    edition = {2},
+    location = {Gliwice},
+    isbn = {978-83-8322-293-6},
+    note = {Wydanie 2 rozszerzone; imprint Helion S.A.}
+}
+
+@book{uml-def,
+    author = {Stanisław Wrycza and Bartosz Marcinkowski and Krzysztof Wyrzykowski},
+    title = {Język UML 2.0 w modelowaniu systemów informatycznych},
+    publisher = {Helion},
+    isbn = {83-736-1892-9, 8373618929},
+    year = {2006},
+    location = {Warszawa}
+}
+
+@book{wzorce-projektowe,
+    author = {Aleksander Shvets},
+    title = {Wzorce Projektowe Nowoczesny Podręcznik},
+    publisher = {Refactoring Guru},
+    year ={2022},
+    location = {Pamplona}
 }

--- a/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
+++ b/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
@@ -6,7 +6,7 @@
 
 W niniejszym podrozdziale opisano sposób integracji aplikacji \glslink{frontend}{frontendowej} z \glslink{backend}{backendem} oraz mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem.
 Jest to kluczowy element aplikacji, ponieważ obejmuje przesyłanie oraz przetwarzanie danych użytkownika.
-W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie biblioteki Axios~\cite{axios} oraz TanStack Query~\cite{tanstack-query},
+W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie \glslink{biblioteka}{biblioteki} Axios~\cite{axios} oraz TanStack Query~\cite{tanstack-query},
 które zapewniają spójny sposób definiowania zapytań, obsługi błędów oraz zarządzania stanem asynchronicznym po stronie klienta.
 
 Zadania asynchroniczne związane z komunikacją z \glslink{api}{API} realizowano z użyciem \texttt{async}/\texttt{await} zgodnie z opisem w \cite[rozdz.~13.3]{flanagan-js-definitive-guide-pl}.

--- a/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
+++ b/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
@@ -4,7 +4,8 @@
 \subsection{Integracja i komunikacja z backendem}
 \label{subsec:integracja-i-komunikacja-z-backendem}
 
-W niniejszym podrozdziale opisano sposób integracji aplikacji \glslink{frontend}{frontendowej} z \glslink{backend}{backendem} oraz mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem.
+W niniejszym podrozdziale opisano sposób integracji aplikacji \glslink{frontend}{frontendowej} z \glslink{backend}{backendem} oraz mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem.\newline
+
 Jest to kluczowy element aplikacji, ponieważ obejmuje przesyłanie oraz przetwarzanie danych użytkownika.
 W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie \glslink{biblioteka}{biblioteki} Axios~\cite{axios} oraz TanStack Query~\cite{tanstack-query},
 które zapewniają spójny sposób definiowania zapytań, obsługi błędów oraz zarządzania stanem asynchronicznym po stronie klienta.

--- a/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
+++ b/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
@@ -9,9 +9,7 @@ Jest to kluczowy element aplikacji, ponieważ obejmuje przesyłanie oraz przetwa
 W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie biblioteki Axios~\cite{axios} oraz TanStack Query~\cite{tanstack-query},
 które zapewniają spójny sposób definiowania zapytań, obsługi błędów oraz zarządzania stanem asynchronicznym po stronie klienta.
 
-W implementacji operacji asynchronicznych (m.in.\ funkcji realizujących zapytania sieciowe i obsługę odpowiedzi serwera) wykorzystano składnię
-\texttt{async}/\texttt{await}, która upraszcza pracę z promesami i pozwala na zapis logiki komunikacji w formie zbliżonej do kodu synchronicznego
-\cite[rozdz.~13.3]{flanagan-js-definitive-guide-pl}.
+Zadania asynchroniczne związane z komunikacją z \glslink{api}{API} realizowano z użyciem \texttt{async}/\texttt{await} zgodnie z opisem w \cite[rozdz.~13.3]{flanagan-js-definitive-guide-pl}.
 
 W przypadku ścieżek wymagających uwierzytelnienia do zapytania dołączany jest token JWT.
 Token przekazywany jest w ciasteczku \textit{HttpOnly}, a jego wysyłanie realizowane jest automatycznie przez przeglądarkę dzięki ustawieniu parametru

--- a/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
+++ b/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
@@ -12,7 +12,7 @@ które zapewniają spójny sposób definiowania zapytań, obsługi błędów ora
 Zadania asynchroniczne związane z komunikacją z \glslink{api}{API} realizowano z użyciem \texttt{async}/\texttt{await} zgodnie z opisem w \cite[rozdz.~13.3]{flanagan-js-definitive-guide-pl}.
 
 W przypadku ścieżek wymagających uwierzytelnienia do zapytania dołączany jest \glslink{token}{token} \glslink{jwt}{JWT}.
-Token przekazywany jest w ciasteczku \textit{HttpOnly}, a jego wysyłanie realizowane jest automatycznie przez przeglądarkę dzięki ustawieniu parametru
+Token przekazywany jest w ciasteczku \glslink{http-only-cookie}{HttpOnly}, a jego wysyłanie realizowane jest automatycznie przez przeglądarkę dzięki ustawieniu parametru
 \texttt{withCredentials} na wartość \texttt{true}. W razie braku tokena lub jego nieważności dostęp do danych nie jest przyznawany.
 Dodatkowo, po odświeżeniu strony lub wejściu na widok w sytuacji, gdy ciasteczko utraciło ważność, sesja jest uznawana za nieaktywną,
 a użytkownik zostaje automatycznie wylogowany. Podczas wylogowania inicjowanego przez użytkownika ciasteczko jest usuwane,

--- a/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
+++ b/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
@@ -4,21 +4,21 @@
 \subsection{Integracja i komunikacja z backendem}
 \label{subsec:integracja-i-komunikacja-z-backendem}
 
-W niniejszym podrozdziale opisano sposób integracji aplikacji \glslink{frontend}{frontendowej} z \glslink{backend}{backendem} oraz
-mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem. \newline
+W niniejszym podrozdziale opisano sposób integracji aplikacji frontendowej z backendem oraz mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem.
+Jest to kluczowy element aplikacji, ponieważ obejmuje przesyłanie oraz przetwarzanie danych użytkownika.
+W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie biblioteki Axios~\cite{axios} oraz TanStack Query~\cite{tanstack-query},
+które zapewniają spójny sposób definiowania zapytań, obsługi błędów oraz zarządzania stanem asynchronicznym po stronie klienta.
 
-Jest to kluczowy element aplikacji, ponieważ wymaga bezpiecznego przesyłania danych użytkownika.
-W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie
-biblioteki \texttt{axios}~\cite{axios} oraz \glslink{biblioteka}{biblioteki} \texttt{TanStack Query}~\cite{tanstack-query}.
+W implementacji operacji asynchronicznych (m.in.\ funkcji realizujących zapytania sieciowe i obsługę odpowiedzi serwera) wykorzystano składnię
+\texttt{async}/\texttt{await}, która upraszcza pracę z promesami i pozwala na zapis logiki komunikacji w formie zbliżonej do kodu synchronicznego
+\cite[rozdz.~13.3]{flanagan-js-definitive-guide-pl}.
 
-W przypadku ścieżek wymagających uwierzytelnienia do zapytania dołączany jest token \gls{jwt}.
-Token przekazywany jest w ciasteczku \glslink{http-only-cookie}{http only}, a jego wysyłanie realizowane jest
-automatycznie przez przeglądarkę dzięki ustawieniu parametru \newline \texttt{withCredentials} na wartość \texttt{true}.
-W razie braku tokena lub jego nieważności dostęp do danych nie jest przyznawany.
-Dodatkowo, po odświeżeniu strony lub wejściu na widok w sytuacji, gdy ciasteczko utraciło ważność, sesja jest
-uznawana za nieaktywną, a użytkownik zostaje automatycznie wylogowany.
-Podczas wylogowania inicjowanego przez użytkownika ciasteczko jest usuwane, co skutkuje utratą uprawnień
-do zasobów chronionych.
+W przypadku ścieżek wymagających uwierzytelnienia do zapytania dołączany jest token JWT.
+Token przekazywany jest w ciasteczku \textit{HttpOnly}, a jego wysyłanie realizowane jest automatycznie przez przeglądarkę dzięki ustawieniu parametru
+\texttt{withCredentials} na wartość \texttt{true}. W razie braku tokena lub jego nieważności dostęp do danych nie jest przyznawany.
+Dodatkowo, po odświeżeniu strony lub wejściu na widok w sytuacji, gdy ciasteczko utraciło ważność, sesja jest uznawana za nieaktywną,
+a użytkownik zostaje automatycznie wylogowany. Podczas wylogowania inicjowanego przez użytkownika ciasteczko jest usuwane,
+co skutkuje utratą uprawnień do zasobów chronionych.
 
 Przykładem pliku odpowiedzialnego za taką komunikację jest \texttt{account.js}
 (rys. \ref{img:account-axios1} i \ref{img:account-axios2}), który obsługuje operacje związane z logowaniem

--- a/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
+++ b/book/chapters/realizacja-projektu/sections/frontend/integracja-z-backendem.tex
@@ -4,14 +4,14 @@
 \subsection{Integracja i komunikacja z backendem}
 \label{subsec:integracja-i-komunikacja-z-backendem}
 
-W niniejszym podrozdziale opisano sposób integracji aplikacji frontendowej z backendem oraz mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem.
+W niniejszym podrozdziale opisano sposób integracji aplikacji \glslink{frontend}{frontendowej} z \glslink{backend}{backendem} oraz mechanizmy odpowiedzialne za bezpieczną i efektywną komunikację z serwerem.
 Jest to kluczowy element aplikacji, ponieważ obejmuje przesyłanie oraz przetwarzanie danych użytkownika.
 W celu uproszczenia komunikacji z serwerem zdecydowano się na wykorzystanie biblioteki Axios~\cite{axios} oraz TanStack Query~\cite{tanstack-query},
 które zapewniają spójny sposób definiowania zapytań, obsługi błędów oraz zarządzania stanem asynchronicznym po stronie klienta.
 
 Zadania asynchroniczne związane z komunikacją z \glslink{api}{API} realizowano z użyciem \texttt{async}/\texttt{await} zgodnie z opisem w \cite[rozdz.~13.3]{flanagan-js-definitive-guide-pl}.
 
-W przypadku ścieżek wymagających uwierzytelnienia do zapytania dołączany jest token JWT.
+W przypadku ścieżek wymagających uwierzytelnienia do zapytania dołączany jest \glslink{token}{token} \glslink{jwt}{JWT}.
 Token przekazywany jest w ciasteczku \textit{HttpOnly}, a jego wysyłanie realizowane jest automatycznie przez przeglądarkę dzięki ustawieniu parametru
 \texttt{withCredentials} na wartość \texttt{true}. W razie braku tokena lub jego nieważności dostęp do danych nie jest przyznawany.
 Dodatkowo, po odświeżeniu strony lub wejściu na widok w sytuacji, gdy ciasteczko utraciło ważność, sesja jest uznawana za nieaktywną,

--- a/book/glossary.tex
+++ b/book/glossary.tex
@@ -399,7 +399,7 @@
     name={UML},
     description={(ang. \textit{Unified Modeling Language});
     graficzny język wizualizacji, specyfikowania oraz dokumentowania składników systemów informatycznych
-    \cite[wstęp, s.~nienumerowana]{uml-def}.}
+    \cite[wstęp, s.~nienumerowana]{uml-def}}
 }
 
 \newglossaryentry{bpmn}{
@@ -896,7 +896,7 @@
         \item \textbf{I} \textendash \space Interface Segregation Principle (tłum. \textit{Zasada Segregacji Interfejsów})
         \item \textbf{D} \textendash \space Dependency Inversion Principle (tłum. \textit{Zasada Odwrócenia Zależności})
     \end{itemize}
-    Definicję opracowano na podstawie treści zawartych w~\cite[rozdz. \textit{Zasady SOLID}]{wzorce-projektowe}.
+    Definicję opracowano na podstawie treści zawartych w~\cite[rozdz. \textit{Zasady SOLID}]{wzorce-projektowe}
     }
 }
 

--- a/book/glossary.tex
+++ b/book/glossary.tex
@@ -398,8 +398,8 @@
 \newglossaryentry{uml}{
     name={UML},
     description={(ang. \textit{Unified Modeling Language});
-    graficzny język wizualizacji, specyfikowania oraz dokumentowania składników systemów informatycznych.
-    Źródło: ~\cite{uml-def}}
+    graficzny język wizualizacji, specyfikowania oraz dokumentowania składników systemów informatycznych
+    \cite[wstęp, s.~nienumerowana]{uml-def}.}
 }
 
 \newglossaryentry{bpmn}{
@@ -896,7 +896,7 @@
         \item \textbf{I} \textendash \space Interface Segregation Principle (tłum. \textit{Zasada Segregacji Interfejsów})
         \item \textbf{D} \textendash \space Dependency Inversion Principle (tłum. \textit{Zasada Odwrócenia Zależności})
     \end{itemize}
-    Definicja została napisana na podstawie treści książki \cite{wzorce-projektowe}
+    Definicję opracowano na podstawie treści zawartych w~\cite[rozdz. \textit{Zasady SOLID}]{wzorce-projektowe}.
     }
 }
 
@@ -927,23 +927,25 @@
 
 \newglossaryentry{react-component}{
     name={Komponent React},
-    description={Podstawowy blok budujący aplikację React, który zwraca \glslink{jsx}{JSX}.
-    Cykl życia komponentu ma trzy stany: montowanie (inicjalizacja i renderowanie),
-    aktualizacja (reagowanie na zmiany), demontowanie (usunięcie komponentu z drzewa \glslink{dom}{DOM}),
-    a ich nazwy muszą zaczynać się wielką literą.
-    Powinien być tworzony w sposób umożliwiający jego wielokrotne użycie w projekcie.
-    Komponenty dzielą się na dwa rodzaje:
-    \begin{itemize}
-        \item \textbf{Komponenty Klasowe} \textemdash \space klasy JavaScript dziedziczące po wbudowanej klasie Component.
-        Pozwalają na zarządzanie stanem poprzez object \textit{state}, zawierający się w każdym komponencie klasowym.
-        Zarządzanie cyklem życia komponentu odbywa się za pomocą wbudowanych metod.
-        Po wprowadzeniu komponentów funkcyjnych nie zaleca się stosowania klasowych.
-        \item \textbf{Komponenty Funkcyjne} \textemdash \space definiowane jak funkcje JavaScript.
-        \glslink{props}{Propsy} są przyjmowane poprzez argumenty funkcji.
-        Zarządzanie stanem oraz cyklem życia komponentu odbywa się za pomocą \glslink{hook}{hook'ów} takich jak
-        \textit{useState}.
-    \end{itemize}}
+    description={
+        Komponenty są cegiełkami wielokrotnego użytku, które łączy się w celu uzyskania ostatecznego interfejsu użytkownika~\cite[s.~36]{schwarzmuller-react-key-concepts-pl}.
+        Cykl życia komponentu ma trzy stany: montowanie (inicjalizacja i renderowanie),
+        aktualizacja (reagowanie na zmiany), demontowanie (usunięcie komponentu z drzewa \glslink{dom}{DOM}),
+        a ich nazwy muszą zaczynać się wielką literą.
+        Powinien być tworzony w sposób umożliwiający jego wielokrotne użycie w projekcie.
+        Komponenty dzielą się na dwa rodzaje:
+        \begin{itemize}
+            \item \textbf{Komponenty Klasowe} \textemdash \space klasy JavaScript dziedziczące po wbudowanej klasie Component.
+            Pozwalają na zarządzanie stanem poprzez object \textit{state}, zawierający się w każdym komponencie klasowym.
+            Zarządzanie cyklem życia komponentu odbywa się za pomocą wbudowanych metod.
+            Po wprowadzeniu komponentów funkcyjnych nie zaleca się stosowania klasowych.
+            \item \textbf{Komponenty Funkcyjne} \textemdash \space definiowane jak funkcje JavaScript.
+            \glslink{props}{Propsy} są przyjmowane poprzez argumenty funkcji.
+            Zarządzanie stanem oraz cyklem życia komponentu odbywa się za pomocą \glslink{hook}{hook'ów} takich jak
+            \textit{useState}.
+        \end{itemize}}
 }
+
 \newglossaryentry{github-actions}{
     name={GitHub Actions},
     description={Platforma CI/CD zintegrowana z portalem GitHub, umożliwiająca automatyzację procesów takich jak
@@ -1148,3 +1150,4 @@
     name={Asynchroniczność},
     description={Sposób wykonywania operacji, w którym ich realizacja nie blokuje dalszego działania aplikacji, a wynik przetwarzania jest obsługiwany w późniejszym czasie}
 }
+

--- a/book/glossary.tex
+++ b/book/glossary.tex
@@ -406,7 +406,7 @@
     name={BPMN},
     description={(ang. \textit{Business Process Model and Notation});
     standard opracowany przez organizację Object Management Group (OMG),
-    którego celem jest dostarczenie czytelnej notacji do opisywania procesów biznesowych~\cite[rozdz.~1, s.~9]{drejewicz-bpmn}.}
+    którego celem jest dostarczenie czytelnej notacji do opisywania procesów biznesowych~\cite[rozdz.~1, s.~9]{drejewicz-bpmn}}
 }
 
 \newglossaryentry{infinite-scroll}{

--- a/book/glossary.tex
+++ b/book/glossary.tex
@@ -405,8 +405,8 @@
 \newglossaryentry{bpmn}{
     name={BPMN},
     description={(ang. \textit{Business Process Model and Notation});
-    standardowa notacja graficzna, która umożliwia szczegółowe przedstawienie i dokumentowanie procesów biznesowych.
-    Źródło: ~\cite{bpmn-def}}
+    standard opracowany przez organizację Object Management Group (OMG),
+    którego celem jest dostarczenie czytelnej notacji do opisywania procesów biznesowych~\cite[rozdz.~1, s.~9]{drejewicz-bpmn}.}
 }
 
 \newglossaryentry{infinite-scroll}{


### PR DESCRIPTION
This pull request updates the bibliography and glossary to improve accuracy, completeness, and citation quality. It adds new references for frontend and BPMN topics, restores previously removed entries, and enhances glossary definitions by citing specific sources and clarifying terminology.

**Bibliography updates and additions:**
* Added references for React (`schwarzmuller-react-key-concepts-pl`) and JavaScript (`flanagan-js-definitive-guide-pl`), and a new BPMN book (`drejewicz-bpmn`). Restored previously removed entries for UML (`uml-def`) and design patterns (`wzorce-projektowe`).
* Removed duplicate or misplaced bibliography entries to avoid redundancy.

**Glossary improvements:**
* Updated the definition of UML to cite a specific section and page from the source (`uml-def`).
* Clarified the BPMN definition to reference the Object Management Group and cite a new book (`drejewicz-bpmn`).
* Revised the SOLID principles entry to cite the relevant chapter from the design patterns book (`wzorce-projektowe`).
* Enhanced the React component definition to reference the new React book and provide a clearer explanation of component reuse (`schwarzmuller-react-key-concepts-pl`).

**Frontend integration documentation:**
* Improved the frontend-backend integration section to reference the new JavaScript book for async/await usage, clarified library usage, and streamlined the explanation of authentication and session handling.